### PR TITLE
[Feat/#6] Kotlin Phase 0-1 빌드 기반 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ my.cnf  # MySQL Exporter 설정 (비밀번호 포함)
 ### Upload Files ###
 uploads/*
 !uploads/.gitkeep
+
+### Local Design Docs (Do not publish) ###
+docs/design/**/*.md
+!README.md
+!readme.me

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,8 @@
 plugins {
     java
+    kotlin("jvm") version "2.2.0"
+    kotlin("plugin.spring") version "2.2.0"
+    kotlin("plugin.jpa") version "2.2.0"
     id("org.springframework.boot") version "4.0.1"
     id("io.spring.dependency-management") version "1.1.7"
 }
@@ -25,6 +28,9 @@ repositories {
 }
 
 dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-validation")


### PR DESCRIPTION
## 🔗 Issue 번호
- related #6

## 🛠 작업 내역
- `.gitignore`에 로컬 설계 문서 비노출 규칙 재추가
- `build.gradle.kts`에 Kotlin 마이그레이션 착수용 플러그인/의존성 추가

## 🔄 변경 사항
- Kotlin 플러그인 추가
  - `kotlin("jvm") version "2.2.0"`
  - `kotlin("plugin.spring") version "2.2.0"`
  - `kotlin("plugin.jpa") version "2.2.0"`
- 의존성 추가
  - `org.jetbrains.kotlin:kotlin-reflect`
  - `com.fasterxml.jackson.module:jackson-module-kotlin`
- 로컬 문서 gitignore 정책 복원

## ✨ 새로운 기능
- 기능 변경 없음 (Phase 0 기반 세팅)

## 📦 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 참고
- Context7(/spring-projects/spring-boot) 기반으로 Kotlin + Spring Boot Gradle 권장 설정 확인 후 반영했습니다.
- `./gradlew build -x test --no-daemon` 성공
- `./gradlew test --no-daemon`는 기존 기준선에서 22개 테스트 실패(사전 존재 이슈)