### PR TITLE
[Feat/#7] Kotlin 기준선 검증 자동화 스크립트 추가

### DIFF
--- a/scripts/phase0-baseline-check.sh
+++ b/scripts/phase0-baseline-check.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PARSE_ONLY="${1:-}"
+GRADLE_EXIT=0
+
+if [ "$PARSE_ONLY" != "--parse-only" ]; then
+  echo "[phase0-baseline] Running test baseline check..."
+  set +e
+  ./gradlew test --no-daemon
+  GRADLE_EXIT=$?
+  set -e
+else
+  echo "[phase0-baseline] Parse-only mode: skipping test execution."
+fi
+
+RESULT_DIR="build/test-results/test"
+
+if [ ! -d "$RESULT_DIR" ]; then
+  echo "[phase0-baseline] No test result directory found: $RESULT_DIR"
+  exit 1
+fi
+
+echo
+echo "[phase0-baseline] Per-suite summary (only failing suites):"
+FAILED_SUITES=0
+
+for f in "$RESULT_DIR"/TEST-*.xml; do
+  [ -f "$f" ] || continue
+
+  tests="$(sed -n 's/.*tests="\([0-9][0-9]*\)".*/\1/p' "$f" | head -n1)"
+  failures="$(sed -n 's/.*failures="\([0-9][0-9]*\)".*/\1/p' "$f" | head -n1)"
+  errors="$(sed -n 's/.*errors="\([0-9][0-9]*\)".*/\1/p' "$f" | head -n1)"
+
+  tests="${tests:-0}"
+  failures="${failures:-0}"
+  errors="${errors:-0}"
+
+  if [ "$failures" -gt 0 ] || [ "$errors" -gt 0 ]; then
+    suite="$(basename "$f" .xml | sed 's/^TEST-//')"
+    echo "- $suite: tests=$tests, failures=$failures, errors=$errors"
+    FAILED_SUITES=$((FAILED_SUITES + 1))
+  fi
+done
+
+echo
+echo "[phase0-baseline] Failed testcases:"
+for f in "$RESULT_DIR"/TEST-*.xml; do
+  [ -f "$f" ] || continue
+  suite="$(basename "$f" .xml | sed 's/^TEST-//')"
+  awk -v suite="$suite" '
+    /<testcase / {
+      current = ""
+      if (match($0, / name="[^"]+"/)) {
+        current = substr($0, RSTART + 7, RLENGTH - 8)
+      }
+    }
+    /<failure / || /<error / {
+      if (current != "") {
+        print "- " suite " :: " current
+      }
+    }
+  ' "$f"
+done
+
+echo
+if [ "$PARSE_ONLY" = "--parse-only" ]; then
+  echo "[phase0-baseline] PARSE-ONLY: test execution skipped."
+elif [ "$GRADLE_EXIT" -eq 0 ]; then
+  echo "[phase0-baseline] PASS: all tests passed."
+else
+  echo "[phase0-baseline] FAIL: test command exited with code $GRADLE_EXIT"
+fi
+
+echo "[phase0-baseline] Failing suites: $FAILED_SUITES"
+echo "[phase0-baseline] HTML report: build/reports/tests/test/index.html"
+
+exit "$GRADLE_EXIT"


### PR DESCRIPTION
## 🔗 Issue 번호
- related #7

## 🛠 작업 내역
- 테스트 기준선 검증 자동화 스크립트 추가
- 실패 테스트 스위트/케이스 요약 출력 구현
- parse-only 모드 지원 (`--parse-only`)

## 🔄 변경 사항
- `scripts/phase0-baseline-check.sh` 추가
  - `./gradlew test --no-daemon` 실행
  - `build/test-results/test/TEST-*.xml` 파싱
  - 실패 스위트 및 테스트 케이스 목록 출력
  - 리포트 경로 출력
- 파싱 정확도 개선
  - testcase `name="..."` 기반 추출
- 실행/파싱 분리
  - `--parse-only` 옵션에서 테스트 재실행 없이 결과만 파싱

## ✨ 새로운 기능
- 마이그레이션 전후 테스트 기준선 비교를 위한 반복 가능한 검증 명령 제공

## 📦 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 실행 예시
- 전체 실행: `./scripts/phase0-baseline-check.sh`
- 결과 파싱만: `./scripts/phase0-baseline-check.sh --parse-only`