### PR TITLE
[Chore/#15] ci workflow 추가, 테스트

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ "main", "develop" ]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: DevCourse
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Debug source snapshot
+        run: |
+          echo "event_name=${{ github.event_name }}"
+          echo "github.sha=${{ github.sha }}"
+          git rev-parse HEAD
+          git log -1 --oneline
+          grep -n "calculateBadge" src/main/java/com/back/domain/post/post/dto/PostListResponse.java || true
+          grep -n "@Builder" src/main/java/com/back/domain/post/post/entity/Post.java || true
+          grep -n "sellerBadge" src/main/java/com/back/domain/search/search/service/SearchService.java || true
+
+      - name: Build (compile)
+        run: ./gradlew clean assemble --no-daemon
+
+      - name: Test (PR fast)
+        if: github.event_name == 'pull_request'
+        env:
+          SPRING_DATASOURCE_URL: jdbc:mysql://127.0.0.1:3306/DevCourse?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+          SPRING_DATASOURCE_USERNAME: root
+          SPRING_DATASOURCE_PASSWORD: root
+          SPRING_DATASOURCE_DRIVER_CLASS_NAME: com.mysql.cj.jdbc.Driver
+        run: ./gradlew test --no-daemon
+
+      - name: Test (push + integration)
+        if: github.event_name == 'push'
+        env:
+          SPRING_DATASOURCE_URL: jdbc:mysql://127.0.0.1:3306/DevCourse?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+          SPRING_DATASOURCE_USERNAME: root
+          SPRING_DATASOURCE_PASSWORD: root
+          SPRING_DATASOURCE_DRIVER_CLASS_NAME: com.mysql.cj.jdbc.Driver
+        run: ./gradlew test integrationTest --no-daemon
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          if-no-files-found: ignore
+          path: |
+            build/reports/tests/test
+            build/reports/tests/integrationTest
+            build/test-results/test
+            build/test-results/integrationTest


### PR DESCRIPTION
## 🔗 Issue 번호
- close #15

## 🛠 작업 내역
PR 생성 시 자동으로 CI가 실행되어 최소한 ./gradlew test가 보장되게 한다.

- 트리거
  - pull_request : pr 이벤트에서 실행
  - push main/develop 푸시 시 실행
- 실행 내용
  - PR 이벤트 : ./gradlew test만 실행 (빠른 피드백)
  - push 이벤트 : ./gradlew test integrationTest 실행
- 구현 상세(초안)
  - PR에서만 PR fast 단계가 돌도록
  - push에서만 integrationTest까지 돌도록
- 체크리스트
  - 로컬에서 ./gradlew test 통과 확인

## 🔄 변경 사항
.github/workflows/ci.yml 파일 추가

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

