### PR TITLE
[Refactor] #58 Auction DTO 참조 안정화 및 Image/Category 영향 가이드

### DIFF
--- a/src/main/java/com/back/domain/auction/auction/dto/response/AuctionDetailResponse.java
+++ b/src/main/java/com/back/domain/auction/auction/dto/response/AuctionDetailResponse.java
@@ -45,7 +45,7 @@ public class AuctionDetailResponse {
         this.status = auction.getStatus();
         this.startAt = auction.getStartAt();
         this.endAt = auction.getEndAt();
-        this.categoryName = auction.getCategory().getName();
+        this.categoryName = auction.getCategory() == null ? null : auction.getCategory().getName();
 
         this.winnerId = auction.getWinnerId();
         this.closedAt = auction.getClosedAt();
@@ -57,7 +57,7 @@ public class AuctionDetailResponse {
                 : null;
 
         this.imageUrls = auction.getAuctionImages().stream()
-                .map(auctionImage -> auctionImage.getImage().getUrl())
+                .map(auctionImage -> auctionImage.getImage() == null ? null : auctionImage.getImage().getUrl())
                 .collect(Collectors.toList());
 
         Double reputationScore = null;

--- a/src/main/java/com/back/domain/auction/auction/dto/response/AuctionListItemDto.java
+++ b/src/main/java/com/back/domain/auction/auction/dto/response/AuctionListItemDto.java
@@ -30,7 +30,7 @@ public class AuctionListItemDto {
         this.status = auction.getStatus();
         this.endAt = auction.getEndAt();
         this.bidCount = auction.getBidCount();
-        this.categoryName = auction.getCategory().getName();
+        this.categoryName = auction.getCategory() == null ? null : auction.getCategory().getName();
 
         Double reputationScore = null;
         if (auction.getSeller().getReputation() != null) {


### PR DESCRIPTION
## 작업 내용
- `AuctionDetailResponse`에서 category/image 참조 null-safe 처리
- `AuctionListItemDto`에서 category 참조 null-safe 처리

## 변경 이유
- Image/Category 공용 도메인 Kotlin 전환 이후, 비정상/누락 데이터에서 DTO 매핑 시 NPE 가능성을 줄이기 위해 방어 로직을 추가했습니다.

## 경매/입찰 외 도메인 영향 시 주의사항 (추가 공유)
### 1) Post
- 영향 파일: `PostService.kt`, `PostListResponse.kt`, `PostDetailResponse.kt`, `Post.kt`
- 주의점: `post.category.name`, `post.postImages.map { it.image.url }` 직접 접근 구간 null-safe 정책 필요

### 2) Member
- 영향 파일: `MemberService.kt`
- 주의점: `Image(imageUrl)` 저장 흐름에서 파일 저장/DB 저장 실패 시 정합성(롤백) 점검 필요

### 3) Chat
- 영향 파일: `ChatService.kt`, `ChatImage.kt`
- 주의점: `findPostMainImages`, `findAuctionMainImages` 결과(`List<Array<Any>>`) 캐스팅 안정성 및 이미지 미존재 응답 정책 점검 필요

### 4) Search
- 영향 파일: `SearchService.java`
- 주의점: `getCategory().getName()`, `getImage().getUrl()` 직접 체인 접근 구간 null-safe 보강 필요 (우선순위 높음)

## 체크리스트
- [x] 경매 DTO null-safe 보강
- [x] 경매/입찰 외 영향 지점 요약 추가
- [ ] 팀 도메인별 후속 반영 여부는 각 담당자가 선택 적용
