### PR TITLE
[Refactor/#71] 채팅 로직 캐스팅 안전성 강화

### DIFF
--- a/src/main/java/com/back/domain/chat/chat/service/ChatService.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/ChatService.kt
@@ -274,8 +274,7 @@ class ChatService(
                     if (postIds.isEmpty()) {
                         emptyMap<Int, String>()
                     } else {
-                        imageRepository.findPostMainImages(postIds)
-                            .associate { row -> (row[0] as Int) to (row[1] as String) }
+                        toMainImageMap(imageRepository.findPostMainImages(postIds), "POST")
                     }
                 },
                 chatTaskExecutor,
@@ -286,8 +285,7 @@ class ChatService(
                     if (auctionIds.isEmpty()) {
                         emptyMap<Int, String>()
                     } else {
-                        imageRepository.findAuctionMainImages(auctionIds)
-                            .associate { row -> (row[0] as Int) to (row[1] as String) }
+                        toMainImageMap(imageRepository.findAuctionMainImages(auctionIds), "AUCTION")
                     }
                 },
                 chatTaskExecutor,
@@ -440,6 +438,27 @@ class ChatService(
         }
     }
 
+    private fun toMainImageMap(rows: List<Array<Any?>>, txType: String): Map<Int, String> =
+        rows.mapNotNull { row -> parseMainImageRow(row, txType) }
+            .toMap()
+
+    private fun parseMainImageRow(row: Array<Any?>, txType: String): Pair<Int, String>? {
+        val itemId = (row.getOrNull(0) as? Number)?.toInt()
+        val imageUrl = row.getOrNull(1) as? String
+
+        if (itemId == null || imageUrl.isNullOrBlank()) {
+            log.warn(
+                "메인 이미지 결과 스킵 - txType: {}, itemIdRaw: {}, imageUrlRaw: {}",
+                txType,
+                row.getOrNull(0),
+                row.getOrNull(1),
+            )
+            return null
+        }
+
+        return itemId to imageUrl
+    }
+
     /** 거래 유형 문자열을 Enum으로 변환 */
     private fun parseTxType(txType: String): ChatRoomType =
         try {
@@ -476,9 +495,7 @@ class ChatService(
     /** 알림 전송 시점에 사용할 아이템 정보 매핑 (직접 조회 기반) */
     private fun resolveNotificationItemInfo(room: ChatRoom): ItemInfo = when (room.txType) {
         ChatRoomType.POST -> room.post?.let { post ->
-            val imageUrl = imageRepository.findPostMainImages(listOf(post.id))
-                .firstOrNull()
-                ?.get(1) as? String
+            val imageUrl = toMainImageMap(imageRepository.findPostMainImages(listOf(post.id)), "POST")[post.id]
 
             ItemInfo(
                 itemId = post.id,
@@ -489,9 +506,7 @@ class ChatService(
         } ?: ItemInfo()
 
         ChatRoomType.AUCTION -> room.auction?.let { auction ->
-            val imageUrl = imageRepository.findAuctionMainImages(listOf(auction.id))
-                .firstOrNull()
-                ?.get(1) as? String
+            val imageUrl = toMainImageMap(imageRepository.findAuctionMainImages(listOf(auction.id)), "AUCTION")[auction.id]
 
             ItemInfo(
                 itemId = auction.id,

--- a/src/main/java/com/back/domain/image/image/repository/ImageRepository.kt
+++ b/src/main/java/com/back/domain/image/image/repository/ImageRepository.kt
@@ -12,11 +12,11 @@ interface ImageRepository : JpaRepository<Image, Int> {
         "SELECT pi.post.id, i.url FROM PostImage pi JOIN pi.image i " +
             "WHERE pi.post.id IN :ids AND pi.image.id = (SELECT MIN(pi2.image.id) FROM PostImage pi2 WHERE pi2.post.id = pi.post.id)"
     )
-    fun findPostMainImages(@Param("ids") ids: List<Int>): List<Array<Any>>
+    fun findPostMainImages(@Param("ids") ids: List<Int>): List<Array<Any?>>
 
     @Query(
         "SELECT ai.auction.id, i.url FROM AuctionImage ai JOIN ai.image i " +
             "WHERE ai.auction.id IN :ids AND ai.image.id = (SELECT MIN(ai2.image.id) FROM AuctionImage ai2 WHERE ai2.auction.id = ai.auction.id)"
     )
-    fun findAuctionMainImages(@Param("ids") ids: List<Int>): List<Array<Any>>
+    fun findAuctionMainImages(@Param("ids") ids: List<Int>): List<Array<Any?>>
 }


### PR DESCRIPTION
## 🔗 Issue 번호
- close #71 

## 🛠 작업 내역
ChatService.kt

- List<Array> 강제 캐스팅 제거
- associate { (row[0] as Int) to (row[1] as String) } 제거

ChatService.kt

- resolveNotificationItemInfo에서 firstOrNull()?.get(1) as? String 대신 안전 파서 재사용

## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

