### PR TITLE
[Chore/#116] GitHub Actions CD 구축: v* 태그 푸시 시 GHCR 빌드/푸시 후 서버에 자동 배포

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,93 @@
+﻿name: CD
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    outputs:
+      image_repo: ${{ steps.meta.outputs.image_repo }}
+      image_tag: ${{ steps.meta.outputs.image_tag }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Prepare image metadata
+        id: meta
+        run: |
+          IMAGE_REPO="ghcr.io/${GITHUB_REPOSITORY,,}"
+          IMAGE_TAG="sha-${GITHUB_SHA::7}"
+          echo "image_repo=${IMAGE_REPO}" >> "$GITHUB_OUTPUT"
+          echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.image_repo }}:${{ steps.meta.outputs.image_tag }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build-and-push
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          IMAGE_REPO: ${{ needs.build-and-push.outputs.image_repo }}
+          IMAGE_TAG: ${{ needs.build-and-push.outputs.image_tag }}
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script_stop: true
+          envs: IMAGE_REPO,IMAGE_TAG,GHCR_USERNAME,GHCR_TOKEN
+          script: |
+            set -euo pipefail
+
+            cd /opt/app
+
+            if grep -q '^IMAGE_TAG=' .env; then
+              sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=${IMAGE_TAG}/" .env
+            else
+              echo "IMAGE_TAG=${IMAGE_TAG}" >> .env
+            fi
+
+            echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
+
+            docker compose pull
+            docker compose up -d
+
+            for i in {1..20}; do
+              status="$(curl -fsS -o /dev/null -w '%{http_code}' http://localhost:8080/actuator/health || true)"
+              if [ "${status}" = "200" ]; then
+                echo "Health check passed"
+                exit 0
+              fi
+              sleep 5
+            done
+
+            echo "Health check failed"
+            exit 1


### PR DESCRIPTION
## 🔗 Issue 번호
- close #116

## 🛠 작업 내역

## 동작 방식

* 트리거

  * `push` tags: `v*`
  * `workflow_dispatch` (수동 실행 가능)
* 이미지 태그 규칙

  * `ghcr.io/<owner>/<repo>:sha-<GITHUB_SHA 7자리>`
* 서버 배포(원격 실행)

  * `/opt/app` 이동
  * `.env`의 `IMAGE_TAG` 값을 최신 값으로 갱신
  * `docker login ghcr.io`
  * `docker compose pull`
  * `docker compose up -d`
  * `http://localhost:8080/actuator/health` 헬스체크(최대 20회, 5초 간격)

## 필요한 Secrets (Repository Secrets)

* `GHCR_USERNAME`: GHCR 로그인 유저명
* `GHCR_TOKEN`: GHCR 토큰(패키지 push/pull 권한 필요)
* `SSH_HOST`: 배포 서버 호스트
* `SSH_USER`: 배포 서버 유저
* `SSH_PRIVATE_KEY`: 배포 서버 접속 키

## 검증 방법

* 아래 중 하나로 확인

  * `v1.0.0` 같은 태그를 푸시 -> GitHub Actions의 `CD` 워크플로우가 성공하는지 확인
  * 서버에서 최신 이미지로 컨테이너가 올라왔는지 확인(IMAGE_TAG / 이미지 sha 태그 확인)
  * `/actuator/health` 200 응답 확인

## 체크리스트

* [ ] Actions에서 `CD` 워크플로우가 v* 태그 푸시에 의해 실행된다
* [ ] GHCR에 이미지가 푸시된다
* [ ] 서버에서 `docker compose pull / up -d`가 수행된다
* [ ] `/actuator/health` 가 200이면 성공으로 종료된다
* [ ] 헬스체크 실패 시 워크플로우가 실패로 종료된다

## 참고

* 서버 배포 경로는 `/opt/app` 기준입니다.
* 헬스체크 엔드포인트는 `/actuator/health` 입니다.


## 🔄 변경 사항
- GitHub Actions CD 워크플로우를 추가했습니다.
- v* 태그를 푸시하면 Docker 이미지를 빌드하고 GHCR에 푸시한 뒤, 서버에 SSH로 접속해 docker compose로 배포합니다.
- 배포 후 /actuator/health 가 200이면 성공으로 판단합니다.

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

