### PR TITLE
[Chore/#128] CD SSH 시크릿 주입 검증 스텝 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check required secrets
+        run: |
+          [ -n "${{ secrets.OCI_HOST }}" ] || (echo "OCI_HOST empty" && exit 1)
+          [ -n "${{ secrets.OCI_USER }}" ] || (echo "OCI_USER empty" && exit 1)
+          [ -n "${{ secrets.OCI_SSH_KEY }}" ] || (echo "OCI_SSH_KEY empty" && exit 1)
+
       - name: Upload deploy compose file
         uses: appleboy/scp-action@v0.1.7
         with:


### PR DESCRIPTION
## 🔗 Issue 번호
- refs #128

## 🛠 작업 내역
- CD deploy job 시작부에 필수 시크릿 존재 검증 스텝 추가
  - `OCI_HOST`
  - `OCI_USER`
  - `OCI_SSH_KEY`

## 🔄 변경 사항
- SSH/SCP 연결 전에 시크릿 누락 여부를 명확히 실패 처리
- `can't connect without a private SSH key or password` 원인 추적 속도 개선

## ✨ 새로운 기능
- 없음 (디버깅/운영 안정성 개선)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?