### PR TITLE
[Chore/#130] prod Redis 의존 제거로 CD 헬스체크 안정화

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,18 +15,14 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
 
-  # Redis 설정 (운영 환경)
-  data:
-    redis:
-      host: localhost
-      port: 6379
-
-  # Cache 설정
+  # Cache 설정 (운영에서는 Redis 미사용)
   cache:
-    type: redis
+    type: simple
+
+management:
+  health:
     redis:
-      time-to-live: 600000  # 10분 (밀리초)
-      cache-null-values: false
+      enabled: false
 
 # 운영 환경 로그 설정
 logging:


### PR DESCRIPTION
## 🔗 Issue 번호
- refs #130

## 🛠 작업 내역
- `application-prod.yml`에서 운영 캐시를 Redis -> simple로 변경
- management health에서 Redis 헬스체크 비활성화

## 🔄 변경 사항
- Redis 컨테이너 없이도 `/actuator/health`가 Redis 때문에 503 반환하지 않도록 조정
- OCI 배포 환경(CD health check)에서 불필요한 Redis 의존 제거

## ✨ 새로운 기능
- 없음 (운영 배포 안정화 설정)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?