### PR TITLE
[Chore/#133] CD 자동 배포 트리거를 main 전용으로 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,7 @@ name: CD
 on:
   workflow_dispatch:
   push:
-    branches: [ "develop" ]
+    branches: [ "main" ]
 
 permissions:
   contents: read


### PR DESCRIPTION
## 🔗 Issue 번호
- refs #133

## 🛠 작업 내역
- `.github/workflows/cd.yml`의 자동 배포 트리거 브랜치를 `develop` -> `main`으로 변경
- `workflow_dispatch` 수동 실행 트리거는 유지

## 🔄 변경 사항
- develop 머지 시 CD가 자동 실행되지 않음
- main 머지(또는 main push) 시에만 CD 자동 실행

## ✨ 새로운 기능
- 없음 (배포 트리거 정책 조정)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?