### PR TITLE
[Fix/#154] OCI ObjectStorage HTTP provider 누락으로 인한 캐너리 기동 실패 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
 
     // OCI Object Storage
     implementation("com.oracle.oci.sdk:oci-java-sdk-objectstorage:3.58.0")
+    implementation("com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey:3.58.0")
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
## 🔗 Issue 번호
- related #154

## 🛠 작업 내역
- `build.gradle.kts`에 OCI SDK HTTP provider 의존성 추가
  - `com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey:3.58.0`

## 🔄 변경 사항
- `OciObjectStorageAdapter` 초기화 시 발생하던 아래 오류를 해결
  - `No http provider available; add dependency on one of the oci-java-sdk-common-httpclient-* choices`

## ✨ 새로운 기능
- 없음 (런타임 의존성 누락 버그 수정)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 검증
- `./gradlew compileKotlin` 성공