### PR TITLE
[Fix/#161] OCI Object Storage 런타임 javax.ws.rs 의존성 누락 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
     // OCI Object Storage
     implementation("com.oracle.oci.sdk:oci-java-sdk-objectstorage:3.58.0")
     implementation("com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey:3.58.0")
+    implementation("javax.ws.rs:javax.ws.rs-api:2.1.1")
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
## 🔗 Issue 번호
- related #161

## 🛠 작업 내역
- `build.gradle.kts`에 OCI 런타임 JAX-RS 의존성 추가
  - `javax.ws.rs:javax.ws.rs-api:2.1.1`

## 🔄 변경 사항
- 캐너리 기동 시 `OciObjectStorageAdapter` 초기화 과정에서 발생한 런타임 오류 해결
  - `NoClassDefFoundError: javax/ws/rs/ProcessingException`

## ✨ 새로운 기능
- 없음 (런타임 의존성 누락 버그 수정)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 검증
- `./gradlew compileKotlin` 성공