### PR TITLE
[Fix/#164] OCI Jersey/JAX-RS LinkageError 충돌 해결 (jersey3 전환)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,8 +77,7 @@ dependencies {
 
     // OCI Object Storage
     implementation("com.oracle.oci.sdk:oci-java-sdk-objectstorage:3.58.0")
-    implementation("com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey:3.58.0")
-    implementation("javax.ws.rs:javax.ws.rs-api:2.1.1")
+    implementation("com.oracle.oci.sdk:oci-java-sdk-common-httpclient-jersey3:3.58.0")
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
## 🔗 Issue 번호
- related #164

## 🛠 작업 내역
- `build.gradle.kts`의 OCI HTTP client 의존성 교체
  - 제거: `oci-java-sdk-common-httpclient-jersey`
  - 제거: `javax.ws.rs:javax.ws.rs-api`
  - 추가: `oci-java-sdk-common-httpclient-jersey3`

## 🔄 변경 사항
- `javax.ws.rs` 기반 수동 의존성과 Jersey2 조합에서 발생하던 LinkageError/ClassCastException 충돌을 제거
- Spring Boot 4(Jakarta) 런타임과 정합성이 맞는 Jersey3 계열로 통일

## ✨ 새로운 기능
- 없음 (런타임 의존성 충돌 버그 수정)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 검증
- `./gradlew compileKotlin` 성공
- 로컬 스모크 실행에서 기존 `javax.ws.rs ClientBuilder` LinkageError 미재현