### PR TITLE
[fix/#184] 클라우드 부하테스트 실행 경로 정합성 수정 및 수동 시드 리셋 지원

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help local-up k6 local-probe-up local-prodlike-up local-up down limits ps logs clean perf-check-env perf
+.PHONY: help local-up k6 local-probe-up local-prodlike-up local-down limits ps logs clean perf-check-env perf
 
 help:
 	@echo ""
@@ -18,8 +18,7 @@ help:
 	@echo "  make perf PERF_SCENARIO=smoke-test ENV=local DOMAIN=auction    # prodlike 환경에서 k6 실행"
 	@echo ""
 	@echo "[Cloud 환경]"
-	@echo "  make local-up ENV=cloud  # cloud 환경 실행"
-	@echo "  make perf ENV=cloud PERF_SCENARIO=load"
+	@echo "  make perf ENV=cloud DOMAIN=auction PERF_SCENARIO=get-load-test"
 	@echo ""
 	@echo "[유틸]"
 	@echo "  make local-down         # 컨테이너 종료"
@@ -51,7 +50,7 @@ local-probe-up:
 	docker compose \
 		-f docker-compose.yml \
 		-f docker/compose/docker-compose.monitoring.yml \
-		-f docker/compose/docker-compose.probe.yml \
+		-f docker/compose/docker-compose.prob.yml \
 		-f docker/compose/docker-compose.local.yml \
 		up -d
 
@@ -66,16 +65,6 @@ local-prodlike-up:
 		-f docker/compose/docker-compose.local.yml \
 		up -d
 
-# ----------------------------
-# 클라우드 환경 (자원 제한 없음)
-# ----------------------------
-cloud-up:
-	docker compose \
-		-f docker/compose/docker-compose.monitoring.yml \
-		-f docker/compose/docker-compose.cloud.yml \
-		up -d
-
-# ----------------------------
 # 공통
 # ----------------------------
 local-down:
@@ -141,4 +130,4 @@ perf: perf-check-env
 	  k6 run \
 	  --summary-export="$(PERF_OUT_JSON)" \
 	  "$(PERF_SCRIPT)"
-	@echo "✅ Saved: perf/results/$(ENV)/$(PERF_SCENARIO)-$(PERF_TS).json"
+	@echo "✅ Saved: perf/results/$(ENV)/$(DOMAIN)/$(PERF_SCENARIO)/$(PERF_SCENARIO)-$(PERF_TS).json"

--- a/docker/compose/docker-compose.k6.yml
+++ b/docker/compose/docker-compose.k6.yml
@@ -15,12 +15,8 @@ services:
       - ../../perf/results:/results
     networks:
       - perf
-      - auction-network
 
 networks:
   perf:
     external: true
     name: perf-network   # prometheus가 속한 네트워크
-  auction-network:
-    external: true
-    name: auction-network

--- a/perf/README.md
+++ b/perf/README.md
@@ -39,7 +39,7 @@ Makefile에 등록된 타겟을 사용합니다.
 
 ```bash
 make local-up
-make perf ENV=local PERF_SCENARIO=smoke PERF_SCRIPT=/scripts/smoke-test.js
+make perf ENV=local DOMAIN=auction PERF_SCENARIO=smoke-test
 ```
 
 >ENV, PERF_SCENARIO, PERF_SCRIPT는 Makefile 기본값이 있으면 생략 가능합니다.
@@ -52,11 +52,17 @@ make perf ENV=local PERF_SCENARIO=smoke PERF_SCRIPT=/scripts/smoke-test.js
 
 - `make local-up` : 로컬 실행(자원 제한 없음)
 - `make k6` : 기본 k6 실행
-- `make local-probe-up` / `make local-probe-k6` : 문제 탐지용(probe) 환경/테스트
-- `make local-prodlike-up` / `make local-prodlike-k6` : 운영 유사(prodlike) 환경/테스트
-- `make down` : 컨테이너 종료
+- `make local-probe-up` : 문제 탐지용(probe) 환경 실행
+- `make local-prodlike-up` : 운영 유사(prodlike) 환경 실행
+- `make local-down` : 컨테이너 종료
 - `make limits` : 컨테이너 CPU/MEM 제한 확인
 - `make logs`, `make ps`, `make clean` 등
+
+클라우드 대상 실행 예시:
+- `make perf ENV=cloud DOMAIN=auction PERF_SCENARIO=get-load-test`
+- `make perf ENV=cloud DOMAIN=bid PERF_SCENARIO=load-test`
+- `make perf ENV=cloud DOMAIN=post PERF_SCENARIO=get-load-test`
+- `make perf ENV=cloud DOMAIN=search PERF_SCENARIO=load-test`
 
 ---
 

--- a/perf/env/cloud.env
+++ b/perf/env/cloud.env
@@ -1,6 +1,6 @@
-BASE_URL=https://158.180.69.190:8080
-# 또는 퍼블릭IP면
-# BASE_URL=http://x.x.x.x:8080
+# CDN/HTTPS를 붙이지 않았다면 http를 사용하세요.
+BASE_URL=http://158.180.69.190:8080
+# 예: BASE_URL=http://x.x.x.x:8080
 POST_CREATE_STEP=1
 POST_CATEGORY_ID=1
 POST_IMAGE_200KB_PATH=./assets/image-200kb.jpg

--- a/perf/k6/scripts/auction/smoke-test.js
+++ b/perf/k6/scripts/auction/smoke-test.js
@@ -1,6 +1,8 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
 
+const BASE_URL = __ENV.BASE_URL || 'http://host.docker.internal:8080';
+
 /**
  * 테스트 옵션 (점진적 부하)
  */
@@ -31,7 +33,7 @@ export function setup() {
 
   for (const user of users) {
     const loginRes = http.post(
-      'http://host.docker.internal:8080/api/v1/members/login',
+      `${BASE_URL}/api/v1/members/login`,
       JSON.stringify({
         username: user.username,
         password: user.password,
@@ -83,7 +85,7 @@ export default function (data) {
 
   // 1️⃣ 내 정보 조회
   const listRes = http.get(
-    'http://host.docker.internal:8080/api/v1/members/me/auctions',
+    `${BASE_URL}/api/v1/members/me/auctions`,
     { headers }
   );
 

--- a/perf/k6/scripts/post/healthcheck.js
+++ b/perf/k6/scripts/post/healthcheck.js
@@ -1,8 +1,10 @@
 import http from 'k6/http';
 import { check } from 'k6';
 
+const BASE_URL = __ENV.BASE_URL || 'http://host.docker.internal:8080';
+
 export default function () {
-  const res = http.get('http://host.docker.internal:8080/actuator/health', { timeout: '3s' });
+  const res = http.get(`${BASE_URL}/actuator/health`, { timeout: '3s' });
   console.log(`status=${res.status} body=${res.body}`);
   check(res, {
     'status is 200': (r) => r.status === 200,

--- a/perf/k6/scripts/test.js
+++ b/perf/k6/scripts/test.js
@@ -1,6 +1,8 @@
 import http from "k6/http";
 import { sleep } from "k6";
 
+const BASE_URL = __ENV.BASE_URL || "http://host.docker.internal:8080";
+
 // vus 10명. 1, 10~50, 100, 1000
 // duration 30초
 export const options = {
@@ -9,7 +11,6 @@ export const options = {
 };
 
 export default function () {
-  // 백엔드 로컬 8080일 시 필요함
-  http.get("http://host.docker.internal:8080/");
+  http.get(`${BASE_URL}/`);
   sleep(1);
 }

--- a/src/main/java/com/back/domain/auction/auction/repository/AuctionRepository.kt
+++ b/src/main/java/com/back/domain/auction/auction/repository/AuctionRepository.kt
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
@@ -47,4 +48,12 @@ interface AuctionRepository : JpaRepository<Auction, Int> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT a FROM Auction a WHERE a.id = :id")
     fun findByIdWithLock(@Param("id") id: Int): Optional<Auction>
+
+    fun countByNameStartingWith(prefix: String): Long
+
+    @Modifying
+    fun deleteByNameStartingWith(prefix: String): Long
+
+    @Query("SELECT a.id FROM Auction a WHERE a.name LIKE CONCAT(:prefix, '%')")
+    fun findIdsByNameStartingWith(@Param("prefix") prefix: String): List<Int>
 }

--- a/src/main/java/com/back/domain/bid/bid/repository/BidRepository.kt
+++ b/src/main/java/com/back/domain/bid/bid/repository/BidRepository.kt
@@ -4,6 +4,7 @@ import com.back.domain.bid.bid.entity.Bid
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
@@ -21,4 +22,7 @@ interface BidRepository : JpaRepository<Bid, Int> {
     fun findTopByAuctionIdOrderByPriceDesc(@Param("auctionId") auctionId: Int): Bid?
 
     fun existsByAuctionIdAndBidderId(auctionId: Int, bidderId: Int): Boolean
+
+    @Modifying
+    fun deleteByAuctionIdIn(auctionIds: Collection<Int>): Long
 }

--- a/src/main/java/com/back/domain/image/image/repository/ImageRepository.kt
+++ b/src/main/java/com/back/domain/image/image/repository/ImageRepository.kt
@@ -19,4 +19,6 @@ interface ImageRepository : JpaRepository<Image, Int> {
             "WHERE ai.auction.id IN :ids AND ai.image.id = (SELECT MIN(ai2.image.id) FROM AuctionImage ai2 WHERE ai2.auction.id = ai.auction.id)"
     )
     fun findAuctionMainImages(@Param("ids") ids: List<Int>): List<Array<Any?>>
+
+    fun deleteByUrlStartingWith(prefix: String): Long
 }

--- a/src/main/java/com/back/domain/post/post/repository/PostRepository.kt
+++ b/src/main/java/com/back/domain/post/post/repository/PostRepository.kt
@@ -42,4 +42,8 @@ interface PostRepository : JpaRepository<Post, Int> {
     fun findBySellerIdAndStatus(sellerId: Int, status: PostStatus, pageable: Pageable): Page<Post>
 
     fun findBySellerId(sellerId: Int, pageable: Pageable): Page<Post>
+
+    fun countByTitleStartingWith(prefix: String): Long
+
+    fun deleteByTitleStartingWith(prefix: String): Long
 }

--- a/src/main/java/com/back/global/seed/LoadtestSeedController.kt
+++ b/src/main/java/com/back/global/seed/LoadtestSeedController.kt
@@ -1,0 +1,24 @@
+package com.back.global.seed
+
+import com.back.global.controller.BaseController
+import com.back.global.rq.Rq
+import com.back.global.rsData.RsData
+import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Profile("loadtest|loadtest-cloud")
+@RestController
+@RequestMapping("/api/v1/loadtest")
+class LoadtestSeedController(
+    rq: Rq,
+    private val loadtestSeeder: LoadtestSeeder
+) : BaseController(rq) {
+
+    @PostMapping("/reset")
+    fun reset(): RsData<Void> {
+        loadtestSeeder.resetByAdmin(authenticatedMemberId)
+        return RsData("200-1", "부하테스트 데이터가 초기화 및 재생성되었습니다.", null)
+    }
+}

--- a/src/main/java/com/back/global/seed/LoadtestSeeder.kt
+++ b/src/main/java/com/back/global/seed/LoadtestSeeder.kt
@@ -2,6 +2,7 @@ package com.back.global.seed
 
 import com.back.domain.auction.auction.entity.Auction
 import com.back.domain.auction.auction.repository.AuctionRepository
+import com.back.domain.bid.bid.repository.BidRepository
 import com.back.domain.category.category.entity.Category
 import com.back.domain.category.category.repository.CategoryRepository
 import com.back.domain.image.image.entity.Image
@@ -18,6 +19,7 @@ import com.back.domain.post.post.entity.PostImage
 import com.back.domain.post.post.entity.PostStatus
 import com.back.domain.post.post.repository.PostRepository
 import com.back.global.app.AppConfig
+import com.back.global.exception.ServiceException
 import jakarta.persistence.EntityManager
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
@@ -32,10 +34,11 @@ import kotlin.random.Random
 @Profile("loadtest|loadtest-cloud")
 @Configuration
 class LoadtestSeeder(
-    @Lazy private val self: LoadtestSeeder, // 내부 호출용 self 주입
+    @Lazy private val self: LoadtestSeeder,
     private val memberService: MemberService,
     private val categoryRepository: CategoryRepository,
     private val auctionRepository: AuctionRepository,
+    private val bidRepository: BidRepository,
     private val reputationRepository: ReputationRepository,
     private val memberRepository: MemberRepository,
     private val postRepository: PostRepository,
@@ -43,9 +46,16 @@ class LoadtestSeeder(
     private val passwordEncoder: PasswordEncoder,
     private val entityManager: EntityManager
 ) {
+    companion object {
+        private const val LT_USER_PREFIX = "user"
+        private const val LT_AUCTION_PREFIX = "[LT-AUCTION]"
+        private const val LT_POST_PREFIX = "[LT-POST]"
+        private const val LT_IMAGE_PREFIX = "/uploads/loadtest/"
+        private const val LT_MEMBER_COUNT = 1000
+    }
 
     @Bean
-    @Profile("loadtest|loadtest-cloud")
+    @Profile("loadtest")
     fun loadTestSeederApplicationRunner() = ApplicationRunner {
         self.work1()
         self.work2()
@@ -55,16 +65,18 @@ class LoadtestSeeder(
 
     @Transactional
     fun work1() {
-        if (memberService.count() > 0) return
-
-        repeat(1000) { i ->
+        repeat(LT_MEMBER_COUNT) { i ->
             val index = i + 1
-            val member = Member("user$index", passwordEncoder.encode("1234"), "유저$index", Role.USER, null).apply {
+            val username = "$LT_USER_PREFIX$index"
+            if (memberRepository.findByUsername(username).isPresent) return@repeat
+
+            val member = Member(username, passwordEncoder.encode("1234"), "LT유저$index", Role.USER, null).apply {
                 if (AppConfig.isNotProd()) modifyApiKey(username)
             }
             memberRepository.save(member)
             reputationRepository.save(Reputation(member, Random.nextDouble(40.0, 100.0)))
         }
+
         entityManager.flush()
         entityManager.clear()
     }
@@ -83,11 +95,11 @@ class LoadtestSeeder(
 
     @Transactional
     fun work3() {
-        if (auctionRepository.count() > 0) return
+        if (auctionRepository.countByNameStartingWith(LT_AUCTION_PREFIX) >= 100_000) return
 
         val members = memberService.findAll()
         val categories = categoryRepository.findAll()
-        if (members.size < 1000 || categories.isEmpty()) return
+        if (members.size < LT_MEMBER_COUNT || categories.isEmpty()) return
 
         val productTypes = arrayOf(
             "아이폰", "갤럭시", "노트북", "태블릿", "에어팟", "청소기", "TV", "냉장고",
@@ -98,7 +110,7 @@ class LoadtestSeeder(
 
         repeat(100_000) { i ->
             val index = i + 1
-            val seller = members[i % 1000]
+            val seller = members[i % LT_MEMBER_COUNT]
             val category = categories[i % categories.size]
             val productName = productTypes[i % productTypes.size]
 
@@ -107,7 +119,7 @@ class LoadtestSeeder(
                 Auction.builder()
                     .seller(seller)
                     .category(category)
-                    .name("$productName #$index")
+                    .name("$LT_AUCTION_PREFIX $productName #$index")
                     .description("서비스 시연용 경매 상품입니다. $index 번째 상품.")
                     .startPrice(startPrice)
                     .buyNowPrice(startPrice * 2)
@@ -116,7 +128,7 @@ class LoadtestSeeder(
                     .build()
             )
 
-            if (index % 1000 == 0) { // 대량 데이터 flush 최적화
+            if (index % 1000 == 0) {
                 entityManager.flush()
                 entityManager.clear()
             }
@@ -128,11 +140,11 @@ class LoadtestSeeder(
     @Transactional
     fun work4() {
         val targetPostCount = 10_000L
-        if (postRepository.count() >= targetPostCount) return
+        if (postRepository.countByTitleStartingWith(LT_POST_PREFIX) >= targetPostCount) return
 
         val sellers = memberService.findAll().filter { it.status == MemberStatus.ACTIVE }
         val categories = categoryRepository.findAll()
-        if (sellers.size < 1_000 || categories.isEmpty()) return
+        if (sellers.size < LT_MEMBER_COUNT || categories.isEmpty()) return
 
         val saleCount = 7_000
         val reservedCount = 2_000
@@ -150,7 +162,7 @@ class LoadtestSeeder(
         val hotspotIds = mutableListOf<Int>()
 
         for (i in 1..10_000) {
-            val seller = sellers[(i - 1) % 1_000]
+            val seller = sellers[(i - 1) % LT_MEMBER_COUNT]
             val category = categories[(i - 1) % categories.size]
 
             val status = when {
@@ -161,8 +173,8 @@ class LoadtestSeeder(
 
             val post = Post(
                 seller,
-                "[LT-POST] 상품 $i",
-                "[LT-POST] loadtest seed content #$i",
+                "$LT_POST_PREFIX 상품 $i",
+                "$LT_POST_PREFIX loadtest seed content #$i",
                 10_000 + (i * 10),
                 category,
                 status,
@@ -198,5 +210,33 @@ class LoadtestSeeder(
             println("[LOADTEST] hotspot post ids (for focused detail mode): $hotspotIds")
             println("[LOADTEST] export as env: POST_HOT_IDS=${hotspotIds[0]},${hotspotIds[1]},${hotspotIds[2]}")
         }
+    }
+
+    @Transactional
+    fun resetByAdmin(actorId: Int) {
+        val actor = memberService.findById(actorId)
+            .orElseThrow { ServiceException("404-1", "존재하지 않는 회원입니다.") }
+
+        if (!actor.isAdmin) {
+            throw ServiceException("403-1", "관리자만 부하테스트 데이터를 재생성할 수 있습니다.")
+        }
+
+        cleanupLoadtestData()
+        work1()
+        work2()
+        work3()
+        work4()
+    }
+
+    @Transactional
+    fun cleanupLoadtestData() {
+        val auctionIds = auctionRepository.findIdsByNameStartingWith(LT_AUCTION_PREFIX)
+        if (auctionIds.isNotEmpty()) {
+            bidRepository.deleteByAuctionIdIn(auctionIds)
+            auctionRepository.deleteByNameStartingWith(LT_AUCTION_PREFIX)
+        }
+
+        postRepository.deleteByTitleStartingWith(LT_POST_PREFIX)
+        imageRepository.deleteByUrlStartingWith(LT_IMAGE_PREFIX)
     }
 }


### PR DESCRIPTION
## 작업 배경
클라우드 부하테스트 실행 경로를 점검한 결과, 실제 실행 시 실패/혼동을 유발하는 불일치가 있었고,
`loadtest-cloud` 프로파일에서 앱 기동 시 대량 자동 시드(10만 경매)가 헬스체크 타임아웃을 유발할 수 있어 배포 안정화가 필요했습니다.

## 변경 사항

### 1) 부하테스트 실행 경로/스크립트 정합성 수정
- `Makefile`
  - `local-probe-up` 경로 오타 수정: `docker-compose.probe.yml` -> `docker-compose.prob.yml`
  - 삭제된 `cloud-up` 타겟 제거 (`docker-compose.cloud.yml` 참조 제거)
  - cloud 실행 안내를 `make perf ENV=cloud DOMAIN=... PERF_SCENARIO=...` 기준으로 정리
  - 결과 저장 로그 경로를 실제 저장 경로와 일치하도록 수정
- `docker/compose/docker-compose.k6.yml`
  - k6의 불필요한 `auction-network` 외부 네트워크 의존 제거
- `perf/env/cloud.env`
  - 기본 `BASE_URL`을 cloud 접속 기준으로 보정 (`http://...:8080`)
- `perf/k6/scripts/auction/smoke-test.js`
- `perf/k6/scripts/post/healthcheck.js`
- `perf/k6/scripts/test.js`
  - `host.docker.internal` 하드코딩 제거, `__ENV.BASE_URL` 기반으로 통일
- `perf/README.md`
  - 실제 타겟/명령어와 맞도록 실행 가이드 정리

### 2) 테스트 데이터 수동 리셋 기능 추가
- `src/main/java/com/back/global/seed/LoadtestSeedController.kt` 추가
  - `POST /api/v1/loadtest/reset`
  - `loadtest|loadtest-cloud` 프로파일에서만 활성화
- `src/main/java/com/back/global/seed/LoadtestSeeder.kt`
  - 관리자만 실행 가능한 `resetByAdmin(actorId)` 추가
  - LT 데이터 정리(`cleanupLoadtestData`) 후 재시딩 수행
  - LT prefix 규칙 명시:
    - 경매: `[LT-AUCTION]`
    - 게시글: `[LT-POST]`
    - 이미지: `/uploads/loadtest/`
  - 시드 idempotent 강화(이미 있는 경우 중복 생성 방지)
  - **자동 시드 실행 Bean 프로파일을 `loadtest`로 축소**
    - 변경 전: `loadtest|loadtest-cloud`
    - 변경 후: `loadtest`
    - 의도: `loadtest-cloud`에서는 앱 기동만 가볍게 하고, 필요 시 수동 reset으로 시드 실행
- 리셋 지원을 위한 repository 메서드 추가
  - `AuctionRepository`, `BidRepository`, `PostRepository`, `ImageRepository`

## 기대 효과
- 로컬/클라우드 부하테스트 실행 경로가 일관되어 실행 실패 가능성 감소
- 클라우드 canary에서 `loadtest-cloud` 배포 시 기동 안정성 향상(자동 대량 시드 제거)
- 테스트 데이터를 "원할 때만" 삭제/재생성 가능

## 로컬 영향
- 기존 로컬 fallback(`host.docker.internal:8080`)은 유지되어 기존 흐름을 깨지 않음
- 오히려 `local-probe-up` 경로 오타가 수정되어 실행 안정성 개선

## 검증
- `./gradlew compileKotlin --no-daemon` 성공

## 참고
- 이슈: #184