### PR TITLE
[fix/#184] LoadtestSeeder Optional 호환 처리 수정

### DIFF
--- a/src/main/java/com/back/global/seed/LoadtestSeeder.kt
+++ b/src/main/java/com/back/global/seed/LoadtestSeeder.kt
@@ -215,7 +215,6 @@ class LoadtestSeeder(
     @Transactional
     fun resetByAdmin(actorId: Int) {
         val actor = memberService.findById(actorId)
-            .orElse(null)
             ?: throw ServiceException("404-1", "존재하지 않는 회원입니다.")
 
         if (!actor.isAdmin) {

--- a/src/main/java/com/back/global/seed/LoadtestSeeder.kt
+++ b/src/main/java/com/back/global/seed/LoadtestSeeder.kt
@@ -215,7 +215,8 @@ class LoadtestSeeder(
     @Transactional
     fun resetByAdmin(actorId: Int) {
         val actor = memberService.findById(actorId)
-            .orElseThrow { ServiceException("404-1", "존재하지 않는 회원입니다.") }
+            .orElse(null)
+            ?: throw ServiceException("404-1", "존재하지 않는 회원입니다.")
 
         if (!actor.isAdmin) {
             throw ServiceException("403-1", "관리자만 부하테스트 데이터를 재생성할 수 있습니다.")


### PR DESCRIPTION
## 관련 이슈
- close #184

## 변경 사항
- `LoadtestSeeder.resetByAdmin`에서 `orElseThrow` 호출을 코틀린/자바 Optional 호환 방식으로 수정
- `memberService.findById(actorId).orElse(null) ?: throw ServiceException(...)` 형태로 변경

## 변경 이유
- 검증 CD 빌드 중 `Unresolved reference 'orElseThrow'` 컴파일 오류가 발생하여 CI가 실패함
- Optional 처리 방식을 프로젝트 내 기존 코틀린 사용 패턴과 맞추어 호환성 문제를 제거함

## 영향 범위
- `src/main/java/com/back/global/seed/LoadtestSeeder.kt` 1개 파일
- 런타임 동작 변화 없이 컴파일 안정성만 개선

## 확인 내용
- 로컬 `./gradlew compileKotlin --no-daemon` 성공
- 기존 시드/리셋 흐름 로직은 유지