### PR TITLE
[fix/#192] loadtest-cloud 부팅 실패(Redis 강제 연결) 제거

### DIFF
--- a/src/main/java/com/back/global/config/RedisConfig.kt
+++ b/src/main/java/com/back/global/config/RedisConfig.kt
@@ -1,5 +1,6 @@
 package com.back.global.config
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory
@@ -10,6 +11,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer
 @Configuration
 class RedisConfig {
     @Bean
+    @ConditionalOnBean(RedisConnectionFactory::class)
     fun redisTemplate(connectionFactory: RedisConnectionFactory): RedisTemplate<String, Any> {
         val template = RedisTemplate<String, Any>()
         template.connectionFactory = connectionFactory

--- a/src/main/resources/application-loadtest-cloud.yml
+++ b/src/main/resources/application-loadtest-cloud.yml
@@ -1,0 +1,61 @@
+ratelimit:
+  enabled: false
+
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+
+  datasource:
+    # loadtest-cloud는 운영과 동일하게 env 주입을 강제한다.
+    # - DB_HOST, DB_PORT, DB_NAME, DB_USERNAME, DB_PASSWORD
+    # - DB_USE_SSL, DB_REQUIRE_SSL, DB_ALLOW_PUBLIC_KEY_RETRIEVAL
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/${DB_NAME}?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=${DB_ALLOW_PUBLIC_KEY_RETRIEVAL:false}&useSSL=${DB_USE_SSL:true}&requireSSL=${DB_REQUIRE_SSL:true}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+    hikari:
+      maximum-pool-size: 10            # AWS RDS t3.micro 기준
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+
+
+  # JPA
+  jpa:
+    show-sql: false                    # 필수 - 로그 왜곡 방지
+    hibernate:
+      ddl-auto: validate               # create/update 절대 금지
+    properties:
+      hibernate:
+        format_sql: false
+        default_batch_fetch_size: 100
+
+
+  # Cache 설정 (loadtest-cloud에서는 Redis 미사용)
+  cache:
+    type: simple
+
+# 로그 레벨 최소화
+logging:
+  level:
+    root: WARN
+    com.back.global.initData: INFO              # INFO
+
+
+# Actuator - Prometheus 수집용
+management:
+  health:
+    redis:
+      enabled: false
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus, metrics
+  metrics:
+    export:
+      prometheus:
+        enabled: true

--- a/src/main/resources/application-loadtest.yml
+++ b/src/main/resources/application-loadtest.yml
@@ -21,18 +21,9 @@ spring:
       idle-timeout: 600000
       max-lifetime: 1800000
 
-  # Redis 설정
-  data:
-    redis:
-      host: ${SPRING_DATA_REDIS_HOST:localhost}
-      port: ${SPRING_DATA_REDIS_PORT:6379}
-
-  # Cache 설정
+  # Cache 설정 (loadtest 프로파일에서는 Redis 미사용)
   cache:
-    type: redis
-    redis:
-      time-to-live: 600000  # 10분 (밀리초)
-      cache-null-values: false
+    type: simple
 
 # 로그 레벨 최소화
 logging:
@@ -43,6 +34,9 @@ logging:
 
 # Actuator - Prometheus 수집용
 management:
+  health:
+    redis:
+      enabled: false
   endpoints:
     web:
       exposure:


### PR DESCRIPTION
## 관련 이슈
- #192

## 변경 사항
- `application-loadtest-cloud.yml`
  - Redis 자동구성 제외 설정 추가
    - `RedisAutoConfiguration`
    - `RedisRepositoriesAutoConfiguration`
  - 캐시 타입을 `simple`로 고정
  - `management.health.redis.enabled=false` 설정
  - DB 설정을 운영(`prod`)과 동일하게 env 필수 방식으로 정렬
    - `DB_HOST/DB_NAME/DB_USERNAME/DB_PASSWORD` fallback 제거
    - SSL 기본값 운영형으로 정렬
- `application-loadtest.yml`
  - 캐시 타입을 `simple`로 변경
  - `management.health.redis.enabled=false` 설정
- `RedisConfig.kt`
  - `redisTemplate` 빈 생성에 `@ConditionalOnBean(RedisConnectionFactory::class)` 적용

## 변경 이유
- canary에서 `SPRING_PROFILES_ACTIVE=loadtest-cloud` 사용 시 Redis(`localhost:6379`) 연결 강제 시도로 애플리케이션 부팅 실패
- health check 503 반복으로 배포 실패 발생
- Redis 미사용 프로파일에서 Redis 관련 자동구성/빈 생성을 차단해 부팅 안정성 확보

## 영향 범위
- loadtest, loadtest-cloud 프로파일의 캐시/헬스/DB 설정
- Redis 서버가 없는 검증 환경에서 안정적으로 기동 가능

## 확인 사항
- `./gradlew compileKotlin --no-daemon` 성공
- 운영(`prod`) 프로파일 동작과 충돌 없음