### PR TITLE
[fix/#192] loadtest 수동 리셋 관리자 제한 제거 및 리셋 API 복원

### DIFF
--- a/src/main/java/com/back/domain/auction/auction/repository/AuctionRepository.kt
+++ b/src/main/java/com/back/domain/auction/auction/repository/AuctionRepository.kt
@@ -47,4 +47,11 @@ interface AuctionRepository : JpaRepository<Auction, Int> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT a FROM Auction a WHERE a.id = :id")
     fun findByIdWithLock(@Param("id") id: Int): Optional<Auction>
+
+    fun countByNameStartingWith(prefix: String): Long
+
+    fun deleteByNameStartingWith(prefix: String): Long
+
+    @Query("SELECT a.id FROM Auction a WHERE a.name LIKE CONCAT(:prefix, '%')")
+    fun findIdsByNameStartingWith(@Param("prefix") prefix: String): List<Int>
 }

--- a/src/main/java/com/back/domain/bid/bid/repository/BidRepository.kt
+++ b/src/main/java/com/back/domain/bid/bid/repository/BidRepository.kt
@@ -21,4 +21,6 @@ interface BidRepository : JpaRepository<Bid, Int> {
     fun findTopByAuctionIdOrderByPriceDesc(@Param("auctionId") auctionId: Int): Bid?
 
     fun existsByAuctionIdAndBidderId(auctionId: Int, bidderId: Int): Boolean
+
+    fun deleteByAuctionIdIn(auctionIds: List<Int>): Long
 }

--- a/src/main/java/com/back/domain/post/post/repository/PostRepository.kt
+++ b/src/main/java/com/back/domain/post/post/repository/PostRepository.kt
@@ -42,4 +42,8 @@ interface PostRepository : JpaRepository<Post, Int> {
     fun findBySellerIdAndStatus(sellerId: Int, status: PostStatus, pageable: Pageable): Page<Post>
 
     fun findBySellerId(sellerId: Int, pageable: Pageable): Page<Post>
+
+    fun countByTitleStartingWith(prefix: String): Long
+
+    fun deleteByTitleStartingWith(prefix: String): Long
 }

--- a/src/main/java/com/back/global/seed/LoadtestSeedController.kt
+++ b/src/main/java/com/back/global/seed/LoadtestSeedController.kt
@@ -1,0 +1,24 @@
+package com.back.global.seed
+
+import com.back.global.controller.BaseController
+import com.back.global.rq.Rq
+import com.back.global.rsData.RsData
+import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Profile("loadtest|loadtest-cloud")
+@RestController
+@RequestMapping("/api/v1/loadtest")
+class LoadtestSeedController(
+    rq: Rq,
+    private val loadtestSeeder: LoadtestSeeder
+) : BaseController(rq) {
+
+    @PostMapping("/reset")
+    fun reset(): RsData<Void?> {
+        loadtestSeeder.reset(authenticatedMemberId)
+        return RsData("200-1", "부하테스트 데이터 재시딩 완료")
+    }
+}

--- a/src/main/java/com/back/global/seed/LoadtestSeeder.kt
+++ b/src/main/java/com/back/global/seed/LoadtestSeeder.kt
@@ -2,6 +2,7 @@ package com.back.global.seed
 
 import com.back.domain.auction.auction.entity.Auction
 import com.back.domain.auction.auction.repository.AuctionRepository
+import com.back.domain.bid.bid.repository.BidRepository
 import com.back.domain.category.category.entity.Category
 import com.back.domain.category.category.repository.CategoryRepository
 import com.back.domain.image.image.entity.Image
@@ -18,6 +19,7 @@ import com.back.domain.post.post.entity.PostImage
 import com.back.domain.post.post.entity.PostStatus
 import com.back.domain.post.post.repository.PostRepository
 import com.back.global.app.AppConfig
+import com.back.global.exception.ServiceException
 import jakarta.persistence.EntityManager
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
@@ -29,13 +31,14 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 import kotlin.random.Random
 
-@Profile("loadtest")
+@Profile("loadtest|loadtest-cloud")
 @Configuration
 class LoadtestSeeder(
     @Lazy private val self: LoadtestSeeder, // 내부 호출용 self 주입
     private val memberService: MemberService,
     private val categoryRepository: CategoryRepository,
     private val auctionRepository: AuctionRepository,
+    private val bidRepository: BidRepository,
     private val reputationRepository: ReputationRepository,
     private val memberRepository: MemberRepository,
     private val postRepository: PostRepository,
@@ -43,6 +46,11 @@ class LoadtestSeeder(
     private val passwordEncoder: PasswordEncoder,
     private val entityManager: EntityManager
 ) {
+    companion object {
+        private const val LT_AUCTION_PREFIX = "[LT-AUCTION]"
+        private const val LT_POST_PREFIX = "[LT-POST]"
+        private const val LT_IMAGE_PREFIX = "/uploads/loadtest/"
+    }
 
     @Bean
     @Profile("loadtest")
@@ -83,7 +91,7 @@ class LoadtestSeeder(
 
     @Transactional
     fun work3() {
-        if (auctionRepository.count() > 0) return
+        if (auctionRepository.countByNameStartingWith(LT_AUCTION_PREFIX) > 0) return
 
         val members = memberService.findAll()
         val categories = categoryRepository.findAll()
@@ -107,7 +115,7 @@ class LoadtestSeeder(
                 Auction.builder()
                     .seller(seller)
                     .category(category)
-                    .name("$productName #$index")
+                    .name("$LT_AUCTION_PREFIX $productName #$index")
                     .description("서비스 시연용 경매 상품입니다. $index 번째 상품.")
                     .startPrice(startPrice)
                     .buyNowPrice(startPrice * 2)
@@ -128,7 +136,7 @@ class LoadtestSeeder(
     @Transactional
     fun work4() {
         val targetPostCount = 10_000L
-        if (postRepository.count() >= targetPostCount) return
+        if (postRepository.countByTitleStartingWith(LT_POST_PREFIX) >= targetPostCount) return
 
         val sellers = memberService.findAll().filter { it.status == MemberStatus.ACTIVE }
         val categories = categoryRepository.findAll()
@@ -161,8 +169,8 @@ class LoadtestSeeder(
 
             val post = Post(
                 seller,
-                "[LT-POST] 상품 $i",
-                "[LT-POST] loadtest seed content #$i",
+                "$LT_POST_PREFIX 상품 $i",
+                "$LT_POST_PREFIX loadtest seed content #$i",
                 10_000 + (i * 10),
                 category,
                 status,
@@ -198,5 +206,33 @@ class LoadtestSeeder(
             println("[LOADTEST] hotspot post ids (for focused detail mode): $hotspotIds")
             println("[LOADTEST] export as env: POST_HOT_IDS=${hotspotIds[0]},${hotspotIds[1]},${hotspotIds[2]}")
         }
+    }
+
+    @Transactional
+    fun reset(actorId: Int) {
+        val actor = memberService.findById(actorId)
+            ?: throw ServiceException("404-1", "존재하지 않는 회원입니다.")
+
+        if (actor.status != MemberStatus.ACTIVE) {
+            throw ServiceException("403-2", "활성 계정만 수동 리셋을 실행할 수 있습니다.")
+        }
+
+        cleanupLoadtestData()
+        work1()
+        work2()
+        work3()
+        work4()
+    }
+
+    @Transactional
+    fun cleanupLoadtestData() {
+        val auctionIds = auctionRepository.findIdsByNameStartingWith(LT_AUCTION_PREFIX)
+        if (auctionIds.isNotEmpty()) {
+            bidRepository.deleteByAuctionIdIn(auctionIds)
+            auctionRepository.deleteByNameStartingWith(LT_AUCTION_PREFIX)
+        }
+
+        postRepository.deleteByTitleStartingWith(LT_POST_PREFIX)
+        imageRepository.deleteByUrlStartingWith(LT_IMAGE_PREFIX)
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #192

## 변경 사항
- `LoadtestSeedController` 추가
  - `POST /api/v1/loadtest/reset` 수동 리셋 엔드포인트 복원
- `LoadtestSeeder` 개선
  - `@Profile("loadtest|loadtest-cloud")`로 확장
  - 관리자 전용 제한 제거(로그인 사용자 기준 실행)
  - `reset(actorId)` 및 `cleanupLoadtestData()` 추가
  - loadtest prefix 기반 데이터 정리 후 재시딩 수행
- 리포지토리 정리 메서드 추가
  - `AuctionRepository`: prefix 기반 count/delete/findIds
  - `BidRepository`: `deleteByAuctionIdIn`
  - `PostRepository`: prefix 기반 count/delete

## 변경 이유
- 현재 수동 리셋 API가 사라진 상태였고, 관리자 계정이 아닌 사용자도 리셋을 실행해야 하는 요구가 있음
- loadtest-cloud 검증 환경에서도 동일한 리셋 기능을 사용할 수 있도록 프로파일 범위를 확장

## 검증
- `./gradlew compileKotlin --no-daemon` 성공