### PR TITLE
[fix/#198] loadtest 리셋 시 기존 사용자 존재로 인한 조기 스킵 수정

### DIFF
--- a/src/main/java/com/back/global/seed/LoadtestSeeder.kt
+++ b/src/main/java/com/back/global/seed/LoadtestSeeder.kt
@@ -47,6 +47,7 @@ class LoadtestSeeder(
     private val entityManager: EntityManager
 ) {
     companion object {
+        private const val LT_MEMBER_TARGET_COUNT = 1000
         private const val LT_AUCTION_PREFIX = "[LT-AUCTION]"
         private const val LT_POST_PREFIX = "[LT-POST]"
         private const val LT_IMAGE_PREFIX = "/uploads/loadtest/"
@@ -63,11 +64,14 @@ class LoadtestSeeder(
 
     @Transactional
     fun work1() {
-        if (memberService.count() > 0) return
-
-        repeat(1000) { i ->
+        repeat(LT_MEMBER_TARGET_COUNT) { i ->
             val index = i + 1
-            val member = Member("user$index", passwordEncoder.encode("1234"), "유저$index", Role.USER, null).apply {
+            val username = "user$index"
+            if (memberRepository.findByUsername(username).isPresent) {
+                return@repeat
+            }
+
+            val member = Member(username, passwordEncoder.encode("1234"), "유저$index", Role.USER, null).apply {
                 if (AppConfig.isNotProd()) modifyApiKey(username)
             }
             memberRepository.save(member)
@@ -93,9 +97,9 @@ class LoadtestSeeder(
     fun work3() {
         if (auctionRepository.countByNameStartingWith(LT_AUCTION_PREFIX) > 0) return
 
-        val members = memberService.findAll()
+        val members = getLoadtestMembers()
         val categories = categoryRepository.findAll()
-        if (members.size < 1000 || categories.isEmpty()) return
+        if (members.size < LT_MEMBER_TARGET_COUNT || categories.isEmpty()) return
 
         val productTypes = arrayOf(
             "아이폰", "갤럭시", "노트북", "태블릿", "에어팟", "청소기", "TV", "냉장고",
@@ -106,7 +110,7 @@ class LoadtestSeeder(
 
         repeat(100_000) { i ->
             val index = i + 1
-            val seller = members[i % 1000]
+            val seller = members[i % LT_MEMBER_TARGET_COUNT]
             val category = categories[i % categories.size]
             val productName = productTypes[i % productTypes.size]
 
@@ -138,9 +142,9 @@ class LoadtestSeeder(
         val targetPostCount = 10_000L
         if (postRepository.countByTitleStartingWith(LT_POST_PREFIX) >= targetPostCount) return
 
-        val sellers = memberService.findAll().filter { it.status == MemberStatus.ACTIVE }
+        val sellers = getLoadtestMembers()
         val categories = categoryRepository.findAll()
-        if (sellers.size < 1_000 || categories.isEmpty()) return
+        if (sellers.size < LT_MEMBER_TARGET_COUNT || categories.isEmpty()) return
 
         val saleCount = 7_000
         val reservedCount = 2_000
@@ -158,7 +162,7 @@ class LoadtestSeeder(
         val hotspotIds = mutableListOf<Int>()
 
         for (i in 1..10_000) {
-            val seller = sellers[(i - 1) % 1_000]
+            val seller = sellers[(i - 1) % LT_MEMBER_TARGET_COUNT]
             val category = categories[(i - 1) % categories.size]
 
             val status = when {
@@ -235,4 +239,9 @@ class LoadtestSeeder(
         postRepository.deleteByTitleStartingWith(LT_POST_PREFIX)
         imageRepository.deleteByUrlStartingWith(LT_IMAGE_PREFIX)
     }
+
+    private fun getLoadtestMembers(): List<Member> =
+        (1..LT_MEMBER_TARGET_COUNT)
+            .mapNotNull { idx -> memberRepository.findByUsername("user$idx").orElse(null) }
+            .filter { it.status == MemberStatus.ACTIVE }
 }


### PR DESCRIPTION
## 관련 이슈
- #198

## 변경 사항
- `LoadtestSeeder.work1()`
  - 기존 `memberService.count() > 0` 전체 사용자 기준 조기 종료 제거
  - `user1 ~ user1000` 사용자별 존재 체크 후 누락 사용자만 생성하도록 변경
- `LoadtestSeeder.work3()`, `work4()`
  - 시드용 판매자 목록을 전체 사용자 대신 `user1 ~ user1000` 기준으로 구성
  - 목표 인원(`1000`) 상수화로 조건 및 인덱싱 일관화
- 내부 유틸 메서드 추가
  - `getLoadtestMembers()`로 loadtest 전용 사용자 집합만 조회

## 변경 이유
- 운영/기존 계정이 1명이라도 있으면 `work1()`이 바로 종료되어 LT 사용자 1000명이 생성되지 않았음
- 이로 인해 `work3()/work4()`가 인원 부족 조건으로 연쇄 스킵되어 리셋 API 성공 후에도 데이터가 생성되지 않는 문제가 발생

## 기대 효과
- 기존 일반/운영 계정 존재 여부와 무관하게 loadtest 전용 사용자 1000명 기준으로 시딩 보장
- 수동 리셋 호출 시 LT 경매/게시글 데이터 생성 안정성 개선

## 검증
- `./gradlew compileKotlin --no-daemon` 성공