### PR TITLE
[fix/#198] loadtest reset 무인증 호출 허용 및 워크플로우 토큰 의존 제거

### DIFF
--- a/.github/workflows/loadtest-run.yml
+++ b/.github/workflows/loadtest-run.yml
@@ -74,9 +74,6 @@ jobs:
           [ -n "${{ secrets.OCI_HOST }}" ] || (echo "OCI_HOST empty" && exit 1)
           [ -n "${{ secrets.OCI_USER }}" ] || (echo "OCI_USER empty" && exit 1)
           [ -n "${{ secrets.OCI_SSH_KEY }}" ] || (echo "OCI_SSH_KEY empty" && exit 1)
-          if [ "${{ inputs.run_reset }}" = "true" ]; then
-            [ -n "${{ secrets.LOADTEST_RESET_TOKEN }}" ] || (echo "LOADTEST_RESET_TOKEN empty (run_reset=true)" && exit 1)
-          fi
 
       - name: Prepare SSH key
         run: |
@@ -96,7 +93,6 @@ jobs:
           DOMAIN: ${{ inputs.domain }}
           SCENARIO: ${{ inputs.scenario }}
           RUN_RESET: ${{ inputs.run_reset }}
-          LOADTEST_RESET_TOKEN: ${{ secrets.LOADTEST_RESET_TOKEN }}
           RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -104,13 +100,12 @@ jobs:
 
           REMOTE_RESULT_PATH="$(
             ssh ${SSH_OPTS} "${OCI_USER}@${OCI_HOST}" \
-              "DEPLOY_PATH='${DEPLOY_PATH}' APP_PORT='${APP_PORT}' BASE_URL='${BASE_URL}' DOMAIN='${DOMAIN}' SCENARIO='${SCENARIO}' RUN_RESET='${RUN_RESET}' LOADTEST_RESET_TOKEN='${LOADTEST_RESET_TOKEN}' RUN_ID='${RUN_ID}' bash -se" <<'EOS'
+              "DEPLOY_PATH='${DEPLOY_PATH}' APP_PORT='${APP_PORT}' BASE_URL='${BASE_URL}' DOMAIN='${DOMAIN}' SCENARIO='${SCENARIO}' RUN_RESET='${RUN_RESET}' RUN_ID='${RUN_ID}' bash -se" <<'EOS'
           set -euo pipefail
           cd "${DEPLOY_PATH}"
 
           if [ "${RUN_RESET}" = "true" ]; then
-            curl -fsS -X POST "http://127.0.0.1:${APP_PORT}/api/v1/loadtest/reset" \
-              -H "Authorization: Bearer ${LOADTEST_RESET_TOKEN}" >/dev/null
+            curl -fsS -X POST "http://127.0.0.1:${APP_PORT}/api/v1/loadtest/reset" >/dev/null
           fi
 
           cp perf/env/cloud.env perf/env/cloud-ci.env

--- a/src/main/java/com/back/global/security/SecurityConfig.kt
+++ b/src/main/java/com/back/global/security/SecurityConfig.kt
@@ -31,6 +31,7 @@ class SecurityConfig(
                 authorize("/api/*/members/login", permitAll)
                 authorize("/api/*/members", permitAll)
                 authorize("/api/*/members/logout", permitAll)
+                authorize(HttpMethod.POST, "/api/*/loadtest/reset", permitAll)
                 authorize(HttpMethod.POST, "/api/*/members", permitAll)
                 authorize(HttpMethod.PATCH, "/api/*/members/me/profile", authenticated)
                 authorize(HttpMethod.GET, "/api/*/auctions/**", permitAll)

--- a/src/main/java/com/back/global/seed/LoadtestSeedController.kt
+++ b/src/main/java/com/back/global/seed/LoadtestSeedController.kt
@@ -1,7 +1,5 @@
 package com.back.global.seed
 
-import com.back.global.controller.BaseController
-import com.back.global.rq.Rq
 import com.back.global.rsData.RsData
 import org.springframework.context.annotation.Profile
 import org.springframework.web.bind.annotation.PostMapping
@@ -12,13 +10,12 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/loadtest")
 class LoadtestSeedController(
-    rq: Rq,
     private val loadtestSeeder: LoadtestSeeder
-) : BaseController(rq) {
+) {
 
     @PostMapping("/reset")
     fun reset(): RsData<Void?> {
-        loadtestSeeder.reset(authenticatedMemberId)
+        loadtestSeeder.reset()
         return RsData("200-1", "부하테스트 데이터 재시딩 완료")
     }
 }

--- a/src/main/java/com/back/global/seed/LoadtestSeeder.kt
+++ b/src/main/java/com/back/global/seed/LoadtestSeeder.kt
@@ -19,7 +19,6 @@ import com.back.domain.post.post.entity.PostImage
 import com.back.domain.post.post.entity.PostStatus
 import com.back.domain.post.post.repository.PostRepository
 import com.back.global.app.AppConfig
-import com.back.global.exception.ServiceException
 import jakarta.persistence.EntityManager
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
@@ -213,14 +212,7 @@ class LoadtestSeeder(
     }
 
     @Transactional
-    fun reset(actorId: Int) {
-        val actor = memberService.findById(actorId)
-            ?: throw ServiceException("404-1", "존재하지 않는 회원입니다.")
-
-        if (actor.status != MemberStatus.ACTIVE) {
-            throw ServiceException("403-2", "활성 계정만 수동 리셋을 실행할 수 있습니다.")
-        }
-
+    fun reset() {
         cleanupLoadtestData()
         work1()
         work2()


### PR DESCRIPTION
## 관련 이슈
- #198

## 변경 사항
- `LoadtestSeedController`
  - `POST /api/v1/loadtest/reset` 호출 시 인증 정보 의존 제거
  - `BaseController` 상속 제거, `loadtestSeeder.reset()` 직접 호출
- `LoadtestSeeder`
  - `reset(actorId)` -> `reset()`으로 변경
  - 사용자 조회/활성 상태 검증 제거
- `SecurityConfig`
  - `POST /api/*/loadtest/reset`를 `permitAll`로 허용
- `loadtest-run.yml`
  - reset 실행 시 `LOADTEST_RESET_TOKEN` 시크릿 의존 제거
  - reset 요청 헤더 토큰 제거

## 변경 이유
- 팀원 공용 부하테스트 실행을 위해 reset API를 헤더 없이 호출 가능하게 단순화
- 워크플로우에서도 별도 reset 토큰 관리 없이 실행 가능하도록 정리

## 검증
- `./gradlew compileKotlin --no-daemon` 성공