### PR TITLE
[feat/#205] 모니터링 스택 액션 배포/종료 워크플로우 추가

### DIFF
--- a/.github/workflows/monitoring-deploy.yml
+++ b/.github/workflows/monitoring-deploy.yml
@@ -1,0 +1,74 @@
+name: Monitoring Deploy
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: monitoring-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check required secrets
+        run: |
+          [ -n "${{ secrets.OCI_HOST }}" ] || (echo "OCI_HOST empty" && exit 1)
+          [ -n "${{ secrets.OCI_USER }}" ] || (echo "OCI_USER empty" && exit 1)
+          [ -n "${{ secrets.OCI_SSH_KEY }}" ] || (echo "OCI_SSH_KEY empty" && exit 1)
+
+      - name: Upload monitoring files
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.OCI_HOST }}
+          port: ${{ secrets.OCI_PORT }}
+          username: ${{ secrets.OCI_USER }}
+          key: ${{ secrets.OCI_SSH_KEY }}
+          source: docker/compose/docker-compose.monitoring.cloud.yml,docker/prometheus/prometheus.canary.yml
+          target: ${{ vars.DEPLOY_PATH || '/home/ubuntu/app' }}
+
+      - name: Deploy monitoring stack via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '/home/ubuntu/app' }}
+        with:
+          host: ${{ secrets.OCI_HOST }}
+          port: ${{ secrets.OCI_PORT }}
+          username: ${{ secrets.OCI_USER }}
+          key: ${{ secrets.OCI_SSH_KEY }}
+          script_stop: true
+          envs: DEPLOY_PATH
+          script: |
+            set -euo pipefail
+
+            mkdir -p "${DEPLOY_PATH}/docker/compose"
+            mkdir -p "${DEPLOY_PATH}/docker/prometheus"
+            cd "${DEPLOY_PATH}"
+
+            docker network create auction-network || true
+            docker network create perf-network || true
+
+            docker compose -p monitoring-cloud -f docker/compose/docker-compose.monitoring.cloud.yml up -d
+
+            for i in {1..20}; do
+              p_ready="$(curl -fsS -o /dev/null -w '%{http_code}' http://localhost:9090/-/ready || true)"
+              g_ready="$(curl -fsS -o /dev/null -w '%{http_code}' http://localhost:3000/api/health || true)"
+              if [ "${p_ready}" = "200" ] && [ "${g_ready}" = "200" ]; then
+                echo "Monitoring stack is healthy"
+                exit 0
+              fi
+              sleep 3
+            done
+
+            echo "Monitoring deploy health check failed"
+            docker ps -a | grep -E 'prometheus-cloud|grafana-cloud' || true
+            docker logs --tail 100 prometheus-cloud || true
+            docker logs --tail 100 grafana-cloud || true
+            exit 1

--- a/.github/workflows/monitoring-down.yml
+++ b/.github/workflows/monitoring-down.yml
@@ -1,0 +1,45 @@
+name: Monitoring Down
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: monitoring-down
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  down:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check required secrets
+        run: |
+          [ -n "${{ secrets.OCI_HOST }}" ] || (echo "OCI_HOST empty" && exit 1)
+          [ -n "${{ secrets.OCI_USER }}" ] || (echo "OCI_USER empty" && exit 1)
+          [ -n "${{ secrets.OCI_SSH_KEY }}" ] || (echo "OCI_SSH_KEY empty" && exit 1)
+
+      - name: Stop monitoring stack via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '/home/ubuntu/app' }}
+        with:
+          host: ${{ secrets.OCI_HOST }}
+          port: ${{ secrets.OCI_PORT }}
+          username: ${{ secrets.OCI_USER }}
+          key: ${{ secrets.OCI_SSH_KEY }}
+          script_stop: true
+          envs: DEPLOY_PATH
+          script: |
+            set -euo pipefail
+
+            cd "${DEPLOY_PATH}"
+            if [ -f "docker/compose/docker-compose.monitoring.cloud.yml" ]; then
+              docker compose -p monitoring-cloud -f docker/compose/docker-compose.monitoring.cloud.yml down
+            else
+              echo "monitoring compose file not found, skip down"
+            fi
+
+            docker ps -a | grep -E 'prometheus-cloud|grafana-cloud' || true


### PR DESCRIPTION
## 관련 이슈
- #205

## 변경 사항
- `.github/workflows/monitoring-deploy.yml` 추가
  - GitHub Actions 수동 실행으로 VM 모니터링 스택 배포
  - 모니터링 파일 업로드 후 `docker compose up -d` 실행
  - Prometheus/Grafana 헬스체크 포함
- `.github/workflows/monitoring-down.yml` 추가
  - GitHub Actions 수동 실행으로 VM 모니터링 스택 종료
  - compose 파일 존재 여부 확인 후 `down` 수행

## 기대 효과
- 팀원이 VM 직접 접속 없이 모니터링 스택을 공통 절차로 제어 가능
- 배포/종료 이력이 Actions에 남아 협업 추적 용이

## 참고
- 사용 시크릿: `OCI_HOST`, `OCI_PORT`, `OCI_USER`, `OCI_SSH_KEY`
- 사용 변수: `DEPLOY_PATH` (미설정 시 `/home/ubuntu/app`)