### PR TITLE
[fix/#209] monitoring deploy perf-network 라벨 충돌 수정

### DIFF
--- a/docker/compose/docker-compose.monitoring.cloud.yml
+++ b/docker/compose/docker-compose.monitoring.cloud.yml
@@ -35,6 +35,7 @@ services:
 
 networks:
   perf:
+    external: true
     name: perf-network
   auction-network:
     external: true


### PR DESCRIPTION
## 관련 이슈
- #209

## 변경 사항
- `docker/compose/docker-compose.monitoring.cloud.yml`
  - `networks.perf`를 `external: true`로 변경

## 변경 이유
- Monitoring Deploy 실행 시 기존 `perf-network`와 compose 관리 네트워크 라벨 충돌 발생
- 외부 네트워크로 명시해 기존 네트워크를 그대로 사용하도록 정렬

## 기대 효과
- `network ... incorrect label` 오류 제거
- 모니터링 스택 배포 액션 안정화