### PR TITLE
[fix/#212] Loadtest Run cloud env Secret 주입 및 파일 fallback 지원

### DIFF
--- a/.github/workflows/loadtest-run.yml
+++ b/.github/workflows/loadtest-run.yml
@@ -93,6 +93,7 @@ jobs:
           DOMAIN: ${{ inputs.domain }}
           SCENARIO: ${{ inputs.scenario }}
           RUN_RESET: ${{ inputs.run_reset }}
+          LOADTEST_CLOUD_ENV: ${{ secrets.LOADTEST_CLOUD_ENV }}
           RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -100,7 +101,7 @@ jobs:
 
           REMOTE_RESULT_PATH="$(
             ssh ${SSH_OPTS} "${OCI_USER}@${OCI_HOST}" \
-              "DEPLOY_PATH='${DEPLOY_PATH}' APP_PORT='${APP_PORT}' BASE_URL='${BASE_URL}' DOMAIN='${DOMAIN}' SCENARIO='${SCENARIO}' RUN_RESET='${RUN_RESET}' RUN_ID='${RUN_ID}' bash -se" <<'EOS'
+              "DEPLOY_PATH='${DEPLOY_PATH}' APP_PORT='${APP_PORT}' BASE_URL='${BASE_URL}' DOMAIN='${DOMAIN}' SCENARIO='${SCENARIO}' RUN_RESET='${RUN_RESET}' LOADTEST_CLOUD_ENV='${LOADTEST_CLOUD_ENV}' RUN_ID='${RUN_ID}' bash -se" <<'EOS'
           set -euo pipefail
           cd "${DEPLOY_PATH}"
 
@@ -108,7 +109,19 @@ jobs:
             curl -fsS -X POST "http://127.0.0.1:${APP_PORT}/api/v1/loadtest/reset" >/dev/null
           fi
 
-          cp perf/env/cloud.env perf/env/cloud-ci.env
+          mkdir -p perf/env
+          if [ -n "${LOADTEST_CLOUD_ENV}" ]; then
+            printf "%s\n" "${LOADTEST_CLOUD_ENV}" > perf/env/cloud-ci.env
+          elif [ -f perf/env/cloud.env ]; then
+            cp perf/env/cloud.env perf/env/cloud-ci.env
+          else
+            cat <<ENV_EOF > perf/env/cloud-ci.env
+BASE_URL=${BASE_URL}
+POST_CREATE_STEP=1
+POST_CATEGORY_ID=1
+ENV_EOF
+          fi
+
           if grep -q '^BASE_URL=' perf/env/cloud-ci.env; then
             sed -i "s|^BASE_URL=.*$|BASE_URL=${BASE_URL}|" perf/env/cloud-ci.env
           else


### PR DESCRIPTION
## 관련 이슈
- #212

## 변경 사항
- `.github/workflows/loadtest-run.yml` 수정
  - `LOADTEST_CLOUD_ENV` 시크릿(멀티라인 env) 지원 추가
  - 실행 시 우선순위:
    1. `LOADTEST_CLOUD_ENV` 시크릿 사용
    2. VM의 `perf/env/cloud.env` 파일 fallback
    3. 둘 다 없으면 최소 기본 env(BASE_URL 등) 자동 생성

## 변경 이유
- VM에 `perf/env/cloud.env` 파일이 없으면 `cp: cannot stat` 오류로 워크플로우 실패
- CD처럼 시크릿 주입 기반으로 동작하도록 보강해 파일 의존도를 낮춤

## 기대 효과
- VM 파일 동기화 여부와 무관하게 Loadtest Run 실행 안정성 향상
- 팀원이 Actions UI에서 바로 부하테스트 실행 가능