### PR TITLE
[release] develop -> main 워크플로우 동기화

### DIFF
--- a/.github/workflows/loadtest-run.yml
+++ b/.github/workflows/loadtest-run.yml
@@ -93,6 +93,7 @@ jobs:
           DOMAIN: ${{ inputs.domain }}
           SCENARIO: ${{ inputs.scenario }}
           RUN_RESET: ${{ inputs.run_reset }}
+          LOADTEST_CLOUD_ENV: ${{ secrets.LOADTEST_CLOUD_ENV }}
           RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -100,7 +101,7 @@ jobs:
 
           REMOTE_RESULT_PATH="$(
             ssh ${SSH_OPTS} "${OCI_USER}@${OCI_HOST}" \
-              "DEPLOY_PATH='${DEPLOY_PATH}' APP_PORT='${APP_PORT}' BASE_URL='${BASE_URL}' DOMAIN='${DOMAIN}' SCENARIO='${SCENARIO}' RUN_RESET='${RUN_RESET}' RUN_ID='${RUN_ID}' bash -se" <<'EOS'
+              "DEPLOY_PATH='${DEPLOY_PATH}' APP_PORT='${APP_PORT}' BASE_URL='${BASE_URL}' DOMAIN='${DOMAIN}' SCENARIO='${SCENARIO}' RUN_RESET='${RUN_RESET}' LOADTEST_CLOUD_ENV='${LOADTEST_CLOUD_ENV}' RUN_ID='${RUN_ID}' bash -se" <<'EOS'
           set -euo pipefail
           cd "${DEPLOY_PATH}"
 
@@ -108,7 +109,19 @@ jobs:
             curl -fsS -X POST "http://127.0.0.1:${APP_PORT}/api/v1/loadtest/reset" >/dev/null
           fi
 
-          cp perf/env/cloud.env perf/env/cloud-ci.env
+          mkdir -p perf/env
+          if [ -n "${LOADTEST_CLOUD_ENV}" ]; then
+            printf "%s\n" "${LOADTEST_CLOUD_ENV}" > perf/env/cloud-ci.env
+          elif [ -f perf/env/cloud.env ]; then
+            cp perf/env/cloud.env perf/env/cloud-ci.env
+          else
+            cat <<ENV_EOF > perf/env/cloud-ci.env
+BASE_URL=${BASE_URL}
+POST_CREATE_STEP=1
+POST_CATEGORY_ID=1
+ENV_EOF
+          fi
+
           if grep -q '^BASE_URL=' perf/env/cloud-ci.env; then
             sed -i "s|^BASE_URL=.*$|BASE_URL=${BASE_URL}|" perf/env/cloud-ci.env
           else


### PR DESCRIPTION
## 목적
- `main` 기준 GitHub Actions에서도 최신 워크플로우를 사용하도록 동기화

## 배경
- Loadtest Run 실행 시 `cp: cannot stat 'perf/env/cloud.env'` 에러 발생
- 원인: `main`에는 `LOADTEST_CLOUD_ENV` Secret fallback이 반영되지 않음

## 포함 내용
- develop의 최신 변경(main 미반영분) 전체 반영
- 특히 `.github/workflows/loadtest-run.yml`의 cloud env Secret/fallback 로직 반영

## 확인 포인트
- 머지 후 Actions에서 Loadtest Run 재실행
- `LOADTEST_CLOUD_ENV` 시크릿 사용 시 VM 파일 미존재여도 정상 진행