### PR TITLE
[fix/#215] Loadtest Run 워크플로우 인식 안정화(name/run-name 명시)

### DIFF
--- a/.github/workflows/loadtest-run.yml
+++ b/.github/workflows/loadtest-run.yml
@@ -1,4 +1,5 @@
-name: Loadtest Run
+name: Loadtest Run Cloud
+run-name: "Loadtest | target=${{ inputs.target }} domain=${{ inputs.domain }} scenario=${{ inputs.scenario }}"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## 관련 이슈
- #215

## 변경 사항
- `.github/workflows/loadtest-run.yml`
  - `name: Loadtest Run Cloud`로 명확화
  - `run-name` 추가로 실행 단위 식별성 향상

## 변경 이유
- Actions UI에서 워크플로우가 파일 경로명으로 보이거나 인식이 불안정한 현상 완화
- 기존 실행 로직/시크릿 fallback 동작은 유지

## 영향 범위
- 워크플로우 메타데이터(표시/가독성) 중심 변경
- 배포/앱 런타임 로직 변경 없음