### PR TITLE
[release] develop -> main (Loadtest Run 워크플로우 인식 안정화 반영)

### DIFF
--- a/.github/workflows/loadtest-run.yml
+++ b/.github/workflows/loadtest-run.yml
@@ -1,4 +1,5 @@
-name: Loadtest Run
+name: Loadtest Run Cloud
+run-name: "Loadtest | target=${{ inputs.target }} domain=${{ inputs.domain }} scenario=${{ inputs.scenario }}"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## 목적
- develop의 최신 워크플로우 변경을 main에 반영

## 포함 변경
- `Loadtest Run` 워크플로우 표시/인식 안정화
  - `name` 명확화
  - `run-name` 추가
- 기존 `LOADTEST_CLOUD_ENV` fallback 로직 유지

## 기대 효과
- Actions 목록에서 워크플로우 식별성 향상
- 수동 실행 시 run 단위 추적성 개선