### PR TITLE
[fix/#222] Loadtest Run 워크플로우 make 의존 제거 및 셸 변수 버그 수정

### DIFF
--- a/.github/workflows/loadtest-run.yml
+++ b/.github/workflows/loadtest-run.yml
@@ -128,12 +128,12 @@ jobs:
 
           mkdir -p "${PERF_OUT_DIR}"
 
-          ENV_ARGS="$$(grep -vE '^\s*#|^\s*$$' perf/env/cloud-ci.env | sed 's/\r$$//' | awk -F= '{printf "-e %s=%s ", $$1, $$2}')"
+          ENV_ARGS="$(grep -vE '^\s*#|^\s*$' perf/env/cloud-ci.env | sed 's/\r$//' | awk -F= '{printf "-e %s=%s ", $1, $2}')"
 
           docker compose \
             -f docker/compose/docker-compose.k6.yml \
             --profile k6 run --rm \
-            $${ENV_ARGS} \
+            ${ENV_ARGS} \
             k6 run \
             --summary-export="${PERF_OUT_CONTAINER_PATH}" \
             "/scripts/${DOMAIN}/${SCENARIO}.js"


### PR DESCRIPTION
## 관련 이슈
- #222

## 변경 사항
- `.github/workflows/loadtest-run.yml`
- `make perf` 제거, 워크플로우에서 직접 `docker compose + k6 run` 실행
- 결과 파일 경로/이름 명시 생성 후 artifact 회수
- 셸 변수 이스케이프 오류(`$$` 사용) 수정

## 기대 효과
- VM Makefile 버전/경로 불일치 문제 제거
- `make: Nothing to be done for 'perf'` 계열 오류 방지
- 원격 실행 초반 `exit 1` 발생 원인(잘못된 변수 치환) 제거