### PR TITLE
[release] develop -> main (Loadtest Run make 의존 제거/버그 수정 반영)

### DIFF
--- a/.github/workflows/loadtest-run.yml
+++ b/.github/workflows/loadtest-run.yml
@@ -128,12 +128,12 @@ jobs:
 
           mkdir -p "${PERF_OUT_DIR}"
 
-          ENV_ARGS="$$(grep -vE '^\s*#|^\s*$$' perf/env/cloud-ci.env | sed 's/\r$$//' | awk -F= '{printf "-e %s=%s ", $$1, $$2}')"
+          ENV_ARGS="$(grep -vE '^\s*#|^\s*$' perf/env/cloud-ci.env | sed 's/\r$//' | awk -F= '{printf "-e %s=%s ", $1, $2}')"
 
           docker compose \
             -f docker/compose/docker-compose.k6.yml \
             --profile k6 run --rm \
-            $${ENV_ARGS} \
+            ${ENV_ARGS} \
             k6 run \
             --summary-export="${PERF_OUT_CONTAINER_PATH}" \
             "/scripts/${DOMAIN}/${SCENARIO}.js"


### PR DESCRIPTION
## 목적
- develop의 Loadtest Run 안정화 변경을 main에 반영

## 포함 변경
- `.github/workflows/loadtest-run.yml`
  - `make perf` 의존 제거
  - 워크플로우에서 직접 `docker compose + k6 run` 실행
  - 결과 파일 생성/검증 로직 명시
  - 셸 변수 이스케이프(`$$`) 버그 수정

## 기대 효과
- VM Makefile 상태와 무관한 부하테스트 실행
- 원격 실행 초반 즉시 실패(exit 1) 재발 방지