### PR TITLE
[fix/#230] 로컬 k6 전용 cloud compose 분리 및 loadtest-run 비활성화

### DIFF
--- a/.github/workflows/loadtest-run.yml
+++ b/.github/workflows/loadtest-run.yml
@@ -1,169 +1,17 @@
-name: Loadtest Run Cloud
-run-name: "Loadtest | target=${{ inputs.target }} domain=${{ inputs.domain }} scenario=${{ inputs.scenario }}"
+name: Loadtest Run Cloud (Deprecated)
 
 on:
   workflow_dispatch:
-    inputs:
-      target:
-        description: "부하테스트 대상"
-        required: true
-        default: "canary"
-        type: choice
-        options:
-          - canary
-          - prod
-      domain:
-        description: "도메인(스크립트 폴더)"
-        required: true
-        default: "auction"
-        type: choice
-        options:
-          - auction
-          - bid
-          - post
-          - search
-          - chat
-      scenario:
-        description: "시나리오 파일명(확장자 제외)"
-        required: true
-        default: "smoke-test"
-        type: string
-      run_reset:
-        description: "테스트 전 loadtest reset API 실행"
-        required: true
-        default: false
-        type: boolean
-      base_url:
-        description: "k6 대상 BASE_URL (비우면 target 기본값 사용)"
-        required: false
-        default: ""
-        type: string
-
-concurrency:
-  group: loadtest-run-${{ inputs.target }}
-  cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
-  run-loadtest:
+  disabled:
+    if: ${{ false }}
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Resolve runtime variables
-        id: vars
+      - name: Deprecated
         run: |
-          if [ "${{ inputs.target }}" = "canary" ]; then
-            APP_PORT="8081"
-          else
-            APP_PORT="8080"
-          fi
-
-          if [ -n "${{ inputs.base_url }}" ]; then
-            BASE_URL="${{ inputs.base_url }}"
-          else
-            BASE_URL="http://127.0.0.1:${APP_PORT}"
-          fi
-
-          echo "app_port=${APP_PORT}" >> "$GITHUB_OUTPUT"
-          echo "base_url=${BASE_URL}" >> "$GITHUB_OUTPUT"
-
-      - name: Check required secrets
-        run: |
-          [ -n "${{ secrets.OCI_HOST }}" ] || (echo "OCI_HOST empty" && exit 1)
-          [ -n "${{ secrets.OCI_USER }}" ] || (echo "OCI_USER empty" && exit 1)
-          [ -n "${{ secrets.OCI_SSH_KEY }}" ] || (echo "OCI_SSH_KEY empty" && exit 1)
-
-      - name: Prepare SSH key
-        run: |
-          mkdir -p ~/.ssh
-          printf "%s\n" "${{ secrets.OCI_SSH_KEY }}" > ~/.ssh/oci_key
-          chmod 600 ~/.ssh/oci_key
-
-      - name: Run loadtest on VM
-        id: run_remote
-        env:
-          OCI_HOST: ${{ secrets.OCI_HOST }}
-          OCI_PORT: ${{ secrets.OCI_PORT || '22' }}
-          OCI_USER: ${{ secrets.OCI_USER }}
-          DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '/home/ubuntu/app' }}
-          APP_PORT: ${{ steps.vars.outputs.app_port }}
-          BASE_URL: ${{ steps.vars.outputs.base_url }}
-          DOMAIN: ${{ inputs.domain }}
-          SCENARIO: ${{ inputs.scenario }}
-          RUN_RESET: ${{ inputs.run_reset }}
-          RUN_ID: ${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          SSH_OPTS="-i ~/.ssh/oci_key -p ${OCI_PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-
-          REMOTE_RESULT_PATH="$(
-            ssh ${SSH_OPTS} "${OCI_USER}@${OCI_HOST}" \
-              "DEPLOY_PATH='${DEPLOY_PATH}' APP_PORT='${APP_PORT}' BASE_URL='${BASE_URL}' DOMAIN='${DOMAIN}' SCENARIO='${SCENARIO}' RUN_RESET='${RUN_RESET}' RUN_ID='${RUN_ID}' bash -se" <<'EOS'
-          set -euo pipefail
-          cd "${DEPLOY_PATH}"
-
-          if [ "${RUN_RESET}" = "true" ]; then
-            curl -fsS -X POST "http://127.0.0.1:${APP_PORT}/api/v1/loadtest/reset" >/dev/null
-          fi
-
-          cp perf/env/cloud.env perf/env/cloud-ci.env
-
-          if grep -q '^BASE_URL=' perf/env/cloud-ci.env; then
-            sed -i "s|^BASE_URL=.*$|BASE_URL=${BASE_URL}|" perf/env/cloud-ci.env
-          else
-            echo "BASE_URL=${BASE_URL}" >> perf/env/cloud-ci.env
-          fi
-
-          SCRIPT_FILE="perf/k6/scripts/${DOMAIN}/${SCENARIO}.js"
-          [ -f "${SCRIPT_FILE}" ] || (echo "k6 script not found: ${SCRIPT_FILE}" && exit 1)
-
-          PERF_TS="$(date +"%Y%m%d-%H%M%S")"
-          PERF_OUT_DIR="perf/results/cloud-ci/${DOMAIN}/${SCENARIO}"
-          PERF_OUT_FILE="${SCENARIO}-${PERF_TS}.json"
-          PERF_OUT_HOST_PATH="${PERF_OUT_DIR}/${PERF_OUT_FILE}"
-          PERF_OUT_CONTAINER_PATH="/results/cloud-ci/${DOMAIN}/${SCENARIO}/${PERF_OUT_FILE}"
-
-          mkdir -p "${PERF_OUT_DIR}"
-
-          ENV_ARGS="$(grep -vE '^\s*#|^\s*$' perf/env/cloud-ci.env | sed 's/\r$//' | awk -F= '{printf "-e %s=%s ", $1, $2}')"
-
-          docker compose \
-            -f docker/compose/docker-compose.k6.yml \
-            --profile k6 run --rm \
-            ${ENV_ARGS} \
-            k6 run \
-            --summary-export="${PERF_OUT_CONTAINER_PATH}" \
-            "/scripts/${DOMAIN}/${SCENARIO}.js"
-
-          [ -f "${PERF_OUT_HOST_PATH}" ] || (echo "result file not found: ${PERF_OUT_HOST_PATH}" && exit 1)
-
-          cp "${PERF_OUT_HOST_PATH}" "/tmp/loadtest-${RUN_ID}.json"
-          echo "/tmp/loadtest-${RUN_ID}.json"
-          EOS
-          )"
-
-          echo "remote_result_path=${REMOTE_RESULT_PATH}" >> "$GITHUB_OUTPUT"
-
-      - name: Download result artifact from VM
-        env:
-          OCI_HOST: ${{ secrets.OCI_HOST }}
-          OCI_PORT: ${{ secrets.OCI_PORT || '22' }}
-          OCI_USER: ${{ secrets.OCI_USER }}
-          REMOTE_RESULT_PATH: ${{ steps.run_remote.outputs.remote_result_path }}
-        run: |
-          set -euo pipefail
-          mkdir -p artifacts
-          SSH_OPTS="-i ~/.ssh/oci_key -p ${OCI_PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-          scp ${SSH_OPTS} "${OCI_USER}@${OCI_HOST}:${REMOTE_RESULT_PATH}" "artifacts/loadtest-result.json"
-
-      - name: Upload result artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: loadtest-result-${{ inputs.target }}-${{ inputs.domain }}-${{ inputs.scenario }}
-          path: artifacts/loadtest-result.json
-          if-no-files-found: error
+          echo "Deprecated workflow."
+          echo "Use local loadtest instead: make perf ENV=cloud DOMAIN=auction PERF_SCENARIO=smoke-test"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help local-up k6 local-probe-up probe-k6 local-prodlike-up prodlike-k6 local-up down limits ps logs clean perf-check-env perf
+.PHONY: help local-up k6 local-probe-up probe-k6 local-prodlike-up prodlike-k6 local-up down limits ps logs clean perf-check-env perf cloud-monitor-up cloud-monitor-down
 
 help:
 	@echo ""
@@ -20,7 +20,7 @@ help:
 	@echo ""
 	@echo "[Cloud 환경]"
 	@echo "  make local-up ENV=cloud  # cloud 환경 실행"
-	@echo "  make perf ENV=cloud PERF_SCENARIO=load"
+	@echo "  make perf ENV=cloud DOMAIN=auction PERF_SCENARIO=smoke-test  # 로컬 k6로 원격 서버 대상 부하테스트"
 	@echo "  make cloud-monitor-up    # VM 전용 모니터링 스택(prometheus+grafana) 실행"
 	@echo "  make cloud-monitor-down  # VM 전용 모니터링 스택 종료"
 	@echo ""
@@ -92,11 +92,6 @@ cloud-up:
 		-f docker/compose/docker-compose.cloud.yml \
 		up -d
 
-k6:
-	docker compose \
-    	-f docker/compose/docker-compose.k6.yml \
-    	run --rm k6
-
 cloud-monitor-up:
 	docker compose \
 		-p monitoring-cloud \
@@ -162,17 +157,22 @@ PERF_TS := $(shell date +"%Y%m%d-%H%M%S")
 PERF_OUT_DIR := $(PERF_RESULTS_ROOT)/$(ENV)/$(DOMAIN)/$(PERF_SCENARIO)
 PERF_OUT_JSON := /results/$(ENV)/$(DOMAIN)/$(PERF_SCENARIO)/$(PERF_SCENARIO)-$(PERF_TS).json
 
+PERF_COMPOSE_FILE := docker/compose/docker-compose.k6.yml
+ifeq ($(ENV),cloud)
+PERF_COMPOSE_FILE := docker/compose/docker-compose.k6.cloud.yml
+endif
+
 perf-check-env:
 	@test -f "$(ENV_FILE)" || (echo "❌ env file not found: $(ENV_FILE)"; exit 1)
 	@mkdir -p "$(PERF_OUT_DIR)"
 
 perf: perf-check-env
-	@echo "▶ Running k6 scenario=$(PERF_SCENARIO) ENV=$(ENV)"
+	@echo "▶ Running k6 scenario=$(PERF_SCENARIO) ENV=$(ENV) compose=$(PERF_COMPOSE_FILE)"
 	MSYS_NO_PATHCONV=1 docker compose \
-	  -f docker/compose/docker-compose.k6.yml \
+	  -f $(PERF_COMPOSE_FILE) \
 	  --profile k6 run --rm \
 	  $$(grep -vE '^\s*#|^\s*$$' "$(ENV_FILE)" | sed 's/\r$$//' | awk -F= '{printf "-e %s=%s ", $$1, $$2}') \
 	  k6 run \
 	  --summary-export="$(PERF_OUT_JSON)" \
 	  "$(PERF_SCRIPT)"
-	@echo "✅ Saved: perf/results/$(ENV)/$(PERF_SCENARIO)-$(PERF_TS).json"
+	@echo "✅ Saved: $(PERF_OUT_DIR)/$(PERF_SCENARIO)-$(PERF_TS).json"

--- a/docker/compose/docker-compose.k6.cloud.yml
+++ b/docker/compose/docker-compose.k6.cloud.yml
@@ -1,0 +1,9 @@
+services:
+  k6:
+    image: grafana/k6:latest
+    container_name: k6-cloud
+    profiles: ["k6"]
+    working_dir: /scripts
+    volumes:
+      - ../../perf/k6/scripts:/scripts:ro
+      - ../../perf/results:/results


### PR DESCRIPTION
## 관련 이슈
- #230

## 변경 사항
- `docker/compose/docker-compose.k6.cloud.yml` 추가
  - 로컬 k6 단독 실행용 compose (외부 네트워크 의존 제거)
- `Makefile` 수정
  - `ENV=cloud`일 때 `docker/compose/docker-compose.k6.cloud.yml` 사용하도록 분기
  - 중복 `k6` 타깃 정리
- `.github/workflows/loadtest-run.yml` 비활성화(Deprecated)
  - GitHub Actions 기반 VM 실행 대신 로컬 실행 전략으로 전환

## 사용 방법
- 로컬에서 원격 서버 대상으로 실행:
  - `make perf ENV=cloud DOMAIN=auction PERF_SCENARIO=smoke-test`
- `perf/env/cloud.env`의 `BASE_URL`을 원격 VM URL로 설정