### PR TITLE
[fix/#234] k6 스크립트 BASE_URL 표준화 및 로컬/클라우드 공통 동작 보강

### DIFF
--- a/perf/k6/scripts/auction/smoke-test.js
+++ b/perf/k6/scripts/auction/smoke-test.js
@@ -1,5 +1,6 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
+import { apiUrl, login } from '../common.js';
 
 /**
  * 테스트 옵션 (점진적 부하)
@@ -30,38 +31,18 @@ export function setup() {
   const authList = [];
 
   for (const user of users) {
-    const loginRes = http.post(
-      'http://host.docker.internal:8080/api/v1/members/login',
-      JSON.stringify({
-        username: user.username,
-        password: user.password,
-      }),
-      {
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
-
-    const success = check(loginRes, {
-      'login status is 200': (r) => r.status === 200,
-      'apiKey exists': (r) => r.json('apiKey') !== null,
-      'accessToken exists': (r) => r.json('accessToken') !== null,
+    const credentials = login(user.username, user.password);
+    const success = check(credentials, {
+      'login success': (v) => !!v,
+      'apiKey exists': (v) => !!v?.apiKey,
+      'accessToken exists': (v) => !!v?.accessToken,
     });
 
     if (!success) {
-      console.error(loginRes.body);
       throw new Error(`Login failed for user: ${user.username}`);
     }
 
-    const apiKey = loginRes.json('data.apiKey');
-    const accessToken = loginRes.json('data.accessToken');
-
-    if (!apiKey || !accessToken) {
-    console.error(loginRes.body);
-    throw new Error('apiKey or accessToken is null');
-    }
-
-    authList.push({ apiKey, accessToken });
-
+    authList.push(credentials);
   }
 
   return { authList };
@@ -83,7 +64,7 @@ export default function (data) {
 
   // 1️⃣ 내 정보 조회
   const listRes = http.get(
-    'http://host.docker.internal:8080/api/v1/members/me/auctions',
+    apiUrl('/api/v1/members/me/auctions'),
     { headers }
   );
 

--- a/perf/k6/scripts/common.js
+++ b/perf/k6/scripts/common.js
@@ -1,7 +1,21 @@
 // k6/scripts/common.js
 import http from 'k6/http';
 
-export const BASE_URL = __ENV.BASE_URL;
+const RAW_BASE_URL = __ENV.BASE_URL || 'http://host.docker.internal:8080';
+export const BASE_URL = RAW_BASE_URL.replace(/\/+$/, '');
+
+export function apiUrl(path) {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${BASE_URL}${normalizedPath}`;
+}
+
+export function safeJson(res) {
+  try {
+    return res.json();
+  } catch (_) {
+    return null;
+  }
+}
 
 // 시딩 계정: user1~user5 (정상), user6(SUSPENDED), user7(BANNED), admin, system
 // 비밀번호: 전부 '1234'
@@ -10,14 +24,14 @@ export const TEST_PASSWORD = '1234';
 
 // 로그인 후 apiKey + accessToken 획득
 export function login(username, password) {
-  const res = http.post(`${BASE_URL}/api/v1/members/login`,
+  const res = http.post(apiUrl('/api/v1/members/login'),
     JSON.stringify({ username, password }),
     { headers: { 'Content-Type': 'application/json' } }
   );
 
-  const body = res.json();
-  if (!body.resultCode?.startsWith('200')) {
-    console.error(`Login failed for ${username}: ${body.msg}`);
+  const body = safeJson(res);
+  if (res.status !== 200 || !body?.resultCode?.startsWith('2')) {
+    console.error(`Login failed for ${username}: status=${res.status}, body=${res.body}`);
     return null;
   }
 

--- a/perf/k6/scripts/post/healthcheck.js
+++ b/perf/k6/scripts/post/healthcheck.js
@@ -1,8 +1,9 @@
 import http from 'k6/http';
 import { check } from 'k6';
+import { apiUrl } from '../common.js';
 
 export default function () {
-  const res = http.get('http://host.docker.internal:8080/actuator/health', { timeout: '3s' });
+  const res = http.get(apiUrl('/actuator/health'), { timeout: '3s' });
   console.log(`status=${res.status} body=${res.body}`);
   check(res, {
     'status is 200': (r) => r.status === 200,

--- a/perf/k6/scripts/search/limit-test.js
+++ b/perf/k6/scripts/search/limit-test.js
@@ -1,7 +1,7 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
+import { BASE_URL } from '../common.js';
 
-const BASE_URL = __ENV.BASE_URL || 'http://host.docker.internal:8080';
 const SCENARIO_TAG = 'search_limit';
 
 const HIT_AUCTION_KEYWORDS = parseList(__ENV.SEARCH_KEYWORDS_HIT_AUCTION, ['아이폰', '갤럭시', '노트북']);

--- a/perf/k6/scripts/search/stress-test.js
+++ b/perf/k6/scripts/search/stress-test.js
@@ -1,7 +1,7 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
+import { BASE_URL } from '../common.js';
 
-const BASE_URL = __ENV.BASE_URL || 'http://host.docker.internal:8080';
 const SCENARIO_TAG = 'search_stress';
 
 const HIT_AUCTION_KEYWORDS = parseList(__ENV.SEARCH_KEYWORDS_HIT_AUCTION, ['아이폰', '갤럭시', '노트북']);

--- a/perf/k6/scripts/test.js
+++ b/perf/k6/scripts/test.js
@@ -1,5 +1,6 @@
 import http from "k6/http";
 import { sleep } from "k6";
+import { BASE_URL } from "./common.js";
 
 // vus 10명. 1, 10~50, 100, 1000
 // duration 30초
@@ -9,7 +10,6 @@ export const options = {
 };
 
 export default function () {
-  // 백엔드 로컬 8080일 시 필요함
-  http.get("http://host.docker.internal:8080/");
+  http.get(`${BASE_URL}/`);
   sleep(1);
 }


### PR DESCRIPTION
## 관련 이슈
- #234

## 변경 사항
- `perf/k6/scripts/common.js`
  - `BASE_URL` 기본값/정규화 추가
  - `apiUrl(path)` 유틸 추가
  - `safeJson(res)` 유틸 추가
  - `login()`에 status/body 방어 로직 강화
- `perf/k6/scripts/auction/smoke-test.js`
  - 하드코딩 URL 제거, `login()`/`apiUrl()` 사용
  - 로그인 체크/파싱 경로 정합성 수정
- `perf/k6/scripts/post/healthcheck.js`
  - 하드코딩 URL 제거 (`apiUrl('/actuator/health')`)
- `perf/k6/scripts/search/limit-test.js`
  - 자체 BASE_URL fallback 제거, 공통 `BASE_URL` 사용
- `perf/k6/scripts/search/stress-test.js`
  - 자체 BASE_URL fallback 제거, 공통 `BASE_URL` 사용
- `perf/k6/scripts/test.js`
  - 하드코딩 URL 제거, 공통 `BASE_URL` 사용

## 기대 효과
- 로컬/클라우드 환경 전환 시 `BASE_URL` 하나로 동일 스크립트 실행 가능
- setup/login 단계에서 null body 파싱 예외 감소
- 스크립트 간 URL 처리 규칙 일관성 확보