### PR TITLE
[fix/#236] k6 인증 분리 및 setup 토큰 재사용 적용

### DIFF
--- a/perf/k6/scripts/auction/get-load-test.js
+++ b/perf/k6/scripts/auction/get-load-test.js
@@ -2,7 +2,7 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Rate, Trend } from 'k6/metrics';
-import { BASE_URL, TEST_USERS, TEST_PASSWORD, login, authHeaders } from '../common.js';
+import { BASE_URL } from '../common.js';
 
 // 커스텀 메트릭
 const errorRate = new Rate('errors');
@@ -31,23 +31,7 @@ export const options = {
   },
 };
 
-// ── 로그인 & 인증 헤더 (VU당 1회만 로그인, 이후 캐싱) ──
-let cachedHeaders = null;
-
-function getHeaders() {
-  if (!cachedHeaders) {
-    const username = TEST_USERS[(__VU - 1) % TEST_USERS.length];
-    const credentials = login(username, TEST_PASSWORD);
-    if (!credentials) return null;
-    cachedHeaders = authHeaders(credentials);
-  }
-  return cachedHeaders;
-}
-
 export default function () {
-  const headers = getHeaders();
-  if (!headers) return;
-
   // ── 📌 경매 도메인 (GET은 permitAll) ──
   group('Auction API', () => {
     const start = Date.now();

--- a/perf/k6/scripts/auction/get-stress-test.js
+++ b/perf/k6/scripts/auction/get-stress-test.js
@@ -2,7 +2,7 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Rate, Trend } from 'k6/metrics';
-import { BASE_URL, TEST_USERS, TEST_PASSWORD, login, authHeaders } from '../common.js';
+import { BASE_URL } from '../common.js';
 
 // 커스텀 메트릭
 const errorRate = new Rate('errors');
@@ -33,23 +33,7 @@ export const options = {
   },
 };
 
-// ── 로그인 & 인증 헤더 (VU당 1회만 로그인, 이후 캐싱) ──
-let cachedHeaders = null;
-
-function getHeaders() {
-  if (!cachedHeaders) {
-    const username = TEST_USERS[(__VU - 1) % TEST_USERS.length];
-    const credentials = login(username, TEST_PASSWORD);
-    if (!credentials) return null;
-    cachedHeaders = authHeaders(credentials);
-  }
-  return cachedHeaders;
-}
-
 export default function () {
-  const headers = getHeaders();
-  if (!headers) return;
-
   // ── 📌 경매 도메인 (GET은 permitAll) ──
   group('Auction API', () => {
     const start = Date.now();

--- a/perf/k6/scripts/auction/smoke-test.js
+++ b/perf/k6/scripts/auction/smoke-test.js
@@ -1,76 +1,21 @@
 import http from 'k6/http';
 import { check, sleep } from 'k6';
-import { apiUrl, login } from '../common.js';
+import { apiUrl } from '../common.js';
 
-/**
- * 테스트 옵션 (점진적 부하)
- */
 export const options = {
   stages: [
-    { duration: '30s', target: 5 },   // 워밍업
-    { duration: '1m', target: 20 },   // 정상 트래픽
-    { duration: '30s', target: 5 },   // 쿨다운
+    { duration: '30s', target: 5 },
+    { duration: '1m', target: 20 },
+    { duration: '30s', target: 5 },
   ],
 };
 
-/**
- * 테스트용 계정 목록
- */
-const users = [
-  { username: 'user1', password: '1234' },
-  { username: 'user2', password: '1234' },
-  { username: 'user3', password: '1234' }
-];
-
-/**
- * setup()
- * - 테스트 시작 전에 1번만 실행
- * - 모든 계정 로그인 → apiKey + accessToken 확보
- */
-export function setup() {
-  const authList = [];
-
-  for (const user of users) {
-    const credentials = login(user.username, user.password);
-    const success = check(credentials, {
-      'login success': (v) => !!v,
-      'apiKey exists': (v) => !!v?.apiKey,
-      'accessToken exists': (v) => !!v?.accessToken,
-    });
-
-    if (!success) {
-      throw new Error(`Login failed for user: ${user.username}`);
-    }
-
-    authList.push(credentials);
-  }
-
-  return { authList };
-}
-
-/**
- * 실제 부하 로직
- * - 각 VU가 랜덤 계정 선택
- * - 인증 필요한 API 호출
- */
-export default function (data) {
-  const auth =
-    data.authList[Math.floor(Math.random() * data.authList.length)];
-
-  const headers = {
-    Authorization: `Bearer ${auth.apiKey} ${auth.accessToken}`,
-  };
-
-
-  // 1️⃣ 내 정보 조회
-  const listRes = http.get(
-    apiUrl('/api/v1/members/me/auctions'),
-    { headers }
-  );
+export default function () {
+  const listRes = http.get(apiUrl('/api/v1/auctions?page=0&size=10'));
 
   check(listRes, {
     'auctions list status is 200': (r) => r.status === 200,
   });
 
-  sleep(1); // 사용자 think time
+  sleep(1);
 }

--- a/perf/k6/scripts/bid/load-test.js
+++ b/perf/k6/scripts/bid/load-test.js
@@ -2,7 +2,7 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Rate, Trend } from 'k6/metrics';
-import { BASE_URL, TEST_USERS, TEST_PASSWORD, login, authHeaders } from '../common.js';
+import { BASE_URL, buildAuthList, pickAuth, authHeaders } from '../common.js';
 
 // 커스텀 메트릭
 const errorRate = new Rate('errors');
@@ -35,27 +35,16 @@ export const options = {
   },
 };
 
-// ── 로그인 & 인증 헤더 (VU당 1회만 로그인, 이후 캐싱) ──
-let cachedHeaders = null;
-let cachedUsername = null;
-
-function getAuth() {
-  if (!cachedHeaders) {
-    const username = TEST_USERS[(__VU - 1) % TEST_USERS.length];
-    const credentials = login(username, TEST_PASSWORD);
-    if (!credentials) return null;
-
-    cachedUsername = username;
-    cachedHeaders = authHeaders(credentials);
-  }
-  return { headers: cachedHeaders, username: cachedUsername };
+export function setup() {
+  return { authList: buildAuthList() };
 }
 
-export default function () {
-  const auth = getAuth();
-  if (!auth) return;
+export default function (data) {
+  const credentials = pickAuth(data?.authList);
+  if (!credentials) return;
 
-  const { headers, username: myUsername } = auth;
+  const headers = authHeaders(credentials);
+  const myUsername = credentials.username;
 
   group('Bid API Only', () => {
     const start = Date.now();

--- a/perf/k6/scripts/bid/stress-test.js
+++ b/perf/k6/scripts/bid/stress-test.js
@@ -2,7 +2,7 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Rate, Trend } from 'k6/metrics';
-import { BASE_URL, TEST_USERS, TEST_PASSWORD, login, authHeaders } from '../common.js';
+import { BASE_URL, buildAuthList, pickAuth, authHeaders } from '../common.js';
 
 // 커스텀 메트릭
 const errorRate = new Rate('errors');
@@ -37,27 +37,15 @@ export const options = {
   },
 };
 
-// ── 로그인 & 인증 헤더 (VU당 1회만 로그인, 이후 캐싱) ──
-let cachedHeaders = null;
-let cachedUsername = null;
-
-function getAuth() {
-  if (!cachedHeaders) {
-    const username = TEST_USERS[(__VU - 1) % TEST_USERS.length];
-    const credentials = login(username, TEST_PASSWORD);
-    if (!credentials) return null;
-
-    cachedUsername = username;
-    cachedHeaders = authHeaders(credentials);
-  }
-  return { headers: cachedHeaders, username: cachedUsername };
+export function setup() {
+  return { authList: buildAuthList() };
 }
 
-export default function () {
-  const auth = getAuth();
-  if (!auth) return;
-
-  const { headers, username: myUsername } = auth;
+export default function (data) {
+  const credentials = pickAuth(data?.authList);
+  if (!credentials) return;
+  const headers = authHeaders(credentials);
+  const myUsername = credentials.username;
 
   group('Bid API Only', () => {
     const start = Date.now();

--- a/perf/k6/scripts/common.js
+++ b/perf/k6/scripts/common.js
@@ -36,6 +36,7 @@ export function login(username, password) {
   }
 
   return {
+    username,
     apiKey: body.data.apiKey,
     accessToken: body.data.accessToken,
   };
@@ -49,6 +50,28 @@ export function authHeaders(credentials) {
       'Authorization': `Bearer ${credentials.apiKey} ${credentials.accessToken}`,
     },
   };
+}
+
+export function authHeader(credentials) {
+  return {
+    Authorization: `Bearer ${credentials.apiKey} ${credentials.accessToken}`,
+  };
+}
+
+export function buildAuthList(users = TEST_USERS, password = TEST_PASSWORD) {
+  const authList = [];
+  for (const username of users) {
+    const credentials = login(username, password);
+    if (credentials?.apiKey && credentials?.accessToken) {
+      authList.push(credentials);
+    }
+  }
+  return authList;
+}
+
+export function pickAuth(authList) {
+  if (!Array.isArray(authList) || authList.length === 0) return null;
+  return authList[(__VU - 1) % authList.length];
 }
 
 // RsData 응답 검증 헬퍼

--- a/perf/k6/scripts/load-test.js
+++ b/perf/k6/scripts/load-test.js
@@ -2,7 +2,7 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Rate, Trend } from 'k6/metrics';
-import { BASE_URL, TEST_USERS, TEST_PASSWORD, login, authHeaders } from '../common.js';
+import { BASE_URL, buildAuthList, pickAuth, authHeaders } from '../common.js';
 
 // 커스텀 메트릭
 const errorRate = new Rate('errors');
@@ -31,23 +31,16 @@ export const options = {
   },
 };
 
-// ── 로그인 & 인증 헤더 (VU당 1회만 로그인, 이후 캐싱) ──
-let cachedHeaders = null;
-
-function getHeaders() {
-  if (!cachedHeaders) {
-    const username = TEST_USERS[(__VU - 1) % TEST_USERS.length];
-    const credentials = login(username, TEST_PASSWORD);
-    if (!credentials) return null;
-    cachedHeaders = authHeaders(credentials);
-  }
-  return cachedHeaders;
+export function setup() {
+  return { authList: buildAuthList() };
 }
 
 // ── 테스트 진행 ──
-export default function () {
-  const headers = getHeaders();
-  if (!headers) return;
+export default function (data) {
+  const credentials = pickAuth(data?.authList);
+  if (!credentials) return;
+  const headers = authHeaders(credentials);
+  const myUsername = credentials.username;
 
   // ── 📌 멤버 도메인 ──
   group('Member API', () => {
@@ -87,8 +80,6 @@ export default function () {
   // ── 📌 입찰 도메인 ──
 	group('Bid API', () => {
 	  const start = Date.now();
-	  const myUsername = TEST_USERS[(__VU - 1) % TEST_USERS.length];
-
 	  // OPEN 상태 경매 여러 개 조회 (분산 입찰용)
 	  const auctions = http.get(`${BASE_URL}/api/v1/auctions?page=0&size=10&status=OPEN`);
 	  const auctionsBody = auctions.json();

--- a/perf/k6/scripts/post/create-load-test.js
+++ b/perf/k6/scripts/post/create-load-test.js
@@ -1,7 +1,7 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Rate, Trend } from 'k6/metrics';
-import { BASE_URL, TEST_USERS, TEST_PASSWORD, login } from '../common.js';
+import { BASE_URL, buildAuthList, pickAuth, authHeader } from '../common.js';
 import { FormData } from 'https://jslib.k6.io/formdata/0.0.2/index.js';
 
 const errorRate = new Rate('errors');
@@ -13,8 +13,6 @@ const CATEGORY_ID = Number(__ENV.POST_CATEGORY_ID || 1);
 const IMAGE_200KB_PATH = __ENV.POST_IMAGE_200KB_PATH || './assets/image-200kb.jpg';
 
 const IMAGE_200KB_BIN = open(IMAGE_200KB_PATH, 'b');
-
-let cachedAuthHeader = null;
 
 export const options = {
   scenarios: {
@@ -36,16 +34,8 @@ export const options = {
   },
 };
 
-function getAuthHeader() {
-  if (!cachedAuthHeader) {
-    const username = TEST_USERS[(__VU - 1) % TEST_USERS.length];
-    const credentials = login(username, TEST_PASSWORD);
-    if (!credentials) return null;
-    cachedAuthHeader = {
-      Authorization: `Bearer ${credentials.apiKey} ${credentials.accessToken}`,
-    };
-  }
-  return cachedAuthHeader;
+export function setup() {
+  return { authList: buildAuthList() };
 }
 
 function parseJson(res) {
@@ -71,9 +61,10 @@ function buildCreatePayload() {
   return form;
 }
 
-export default function () {
-  const authHeader = getAuthHeader();
-  if (!authHeader) return;
+export default function (data) {
+  const credentials = pickAuth(data?.authList);
+  if (!credentials) return;
+  const bearerHeader = authHeader(credentials);
 
   group('Post Create API', () => {
     const createPayload = buildCreatePayload();
@@ -82,7 +73,7 @@ export default function () {
       createPayload.body(),
       {
         headers: {
-          ...authHeader,
+          ...bearerHeader,
           'Content-Type': `multipart/form-data; boundary=${createPayload.boundary}`,
         },
         tags: {
@@ -109,7 +100,7 @@ export default function () {
         `${BASE_URL}/api/v1/posts/${postId}`,
         null,
         {
-          headers: authHeader,
+          headers: bearerHeader,
           tags: {
             scenario: 'post_create_load',
             endpoint: 'post_delete_cleanup',

--- a/perf/k6/scripts/post/create-smoke-test.js
+++ b/perf/k6/scripts/post/create-smoke-test.js
@@ -1,6 +1,6 @@
 import http from 'k6/http';
 import { check } from 'k6';
-import { BASE_URL, TEST_USERS, TEST_PASSWORD, login } from '../common.js';
+import { BASE_URL, TEST_USERS, buildAuthList, pickAuth, authHeader } from '../common.js';
 import { FormData } from 'https://jslib.k6.io/formdata/0.0.2/index.js';
 
 const CREATE_STEP = Math.max(1, Math.min(2, Number(__ENV.POST_CREATE_STEP || 1)));
@@ -25,6 +25,10 @@ export const options = {
   },
 };
 
+export function setup() {
+  return { authList: buildAuthList([TEST_USERS[0]]) };
+}
+
 function parseJson(res) {
   try {
     return res.json();
@@ -48,14 +52,12 @@ function buildCreatePayload() {
   return form;
 }
 
-export default function () {
-  const credentials = login(TEST_USERS[0], TEST_PASSWORD);
+export default function (data) {
+  const credentials = pickAuth(data?.authList);
   check(credentials, { 'login success': (v) => !!v });
   if (!credentials) return;
 
-  const authHeader = {
-    Authorization: `Bearer ${credentials.apiKey} ${credentials.accessToken}`,
-  };
+  const bearerHeader = authHeader(credentials);
 
   const createPayload = buildCreatePayload();
   const createRes = http.post(
@@ -63,7 +65,7 @@ export default function () {
     createPayload.body(),
     {
       headers: {
-        ...authHeader,
+        ...bearerHeader,
         'Content-Type': `multipart/form-data; boundary=${createPayload.boundary}`,
       },
       tags: {
@@ -92,7 +94,7 @@ export default function () {
     `${BASE_URL}/api/v1/posts/${postId}`,
     null,
     {
-      headers: authHeader,
+      headers: bearerHeader,
       tags: {
         scenario: 'post_create_smoke',
         endpoint: 'post_delete_cleanup',

--- a/perf/k6/scripts/post/create-stress-test.js
+++ b/perf/k6/scripts/post/create-stress-test.js
@@ -1,7 +1,7 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Rate, Trend } from 'k6/metrics';
-import { BASE_URL, TEST_USERS, TEST_PASSWORD, login } from '../common.js';
+import { BASE_URL, buildAuthList, pickAuth, authHeader } from '../common.js';
 import { FormData } from 'https://jslib.k6.io/formdata/0.0.2/index.js';
 
 const errorRate = new Rate('errors');
@@ -13,8 +13,6 @@ const CATEGORY_ID = Number(__ENV.POST_CATEGORY_ID || 1);
 const IMAGE_200KB_PATH = __ENV.POST_IMAGE_200KB_PATH || './assets/image-200kb.jpg';
 
 const IMAGE_200KB_BIN = open(IMAGE_200KB_PATH, 'b');
-
-let cachedAuthHeader = null;
 
 export const options = {
   scenarios: {
@@ -38,16 +36,8 @@ export const options = {
   },
 };
 
-function getAuthHeader() {
-  if (!cachedAuthHeader) {
-    const username = TEST_USERS[(__VU - 1) % TEST_USERS.length];
-    const credentials = login(username, TEST_PASSWORD);
-    if (!credentials) return null;
-    cachedAuthHeader = {
-      Authorization: `Bearer ${credentials.apiKey} ${credentials.accessToken}`,
-    };
-  }
-  return cachedAuthHeader;
+export function setup() {
+  return { authList: buildAuthList() };
 }
 
 function parseJson(res) {
@@ -73,9 +63,10 @@ function buildCreatePayload() {
   return form;
 }
 
-export default function () {
-  const authHeader = getAuthHeader();
-  if (!authHeader) return;
+export default function (data) {
+  const credentials = pickAuth(data?.authList);
+  if (!credentials) return;
+  const bearerHeader = authHeader(credentials);
 
   group('Post Create API', () => {
     const createPayload = buildCreatePayload();
@@ -84,7 +75,7 @@ export default function () {
       createPayload.body(),
       {
         headers: {
-          ...authHeader,
+          ...bearerHeader,
           'Content-Type': `multipart/form-data; boundary=${createPayload.boundary}`,
         },
         tags: {
@@ -111,7 +102,7 @@ export default function () {
         `${BASE_URL}/api/v1/posts/${postId}`,
         null,
         {
-          headers: authHeader,
+          headers: bearerHeader,
           tags: {
             scenario: 'post_create_stress',
             endpoint: 'post_delete_cleanup',

--- a/perf/k6/scripts/post/get-load-test.js
+++ b/perf/k6/scripts/post/get-load-test.js
@@ -1,7 +1,7 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Rate, Trend } from 'k6/metrics';
-import { BASE_URL, TEST_USERS, TEST_PASSWORD, login, authHeaders } from '../common.js';
+import { BASE_URL } from '../common.js';
 
 const errorRate = new Rate('errors');
 const postListDuration = new Trend('post_list_duration');
@@ -14,7 +14,6 @@ const HOT_IDS = (__ENV.POST_HOT_IDS || '')
   .filter((v) => Number.isFinite(v) && v > 0);
 const CACHED_ID_SIZE = Math.max(1, Number(__ENV.POST_CACHED_ID_SIZE || 3));
 
-let cachedHeaders = null;
 let cachedPostIds = [];
 
 export const options = {
@@ -36,16 +35,6 @@ export const options = {
     errors: ['rate<0.005'],
   },
 };
-
-function getHeaders() {
-  if (!cachedHeaders) {
-    const username = TEST_USERS[(__VU - 1) % TEST_USERS.length];
-    const credentials = login(username, TEST_PASSWORD);
-    if (!credentials) return null;
-    cachedHeaders = authHeaders(credentials);
-  }
-  return cachedHeaders;
-}
 
 function parseJson(res) {
   try {
@@ -102,13 +91,10 @@ function pickDetailId(listIds) {
 }
 
 export default function () {
-  const headers = getHeaders();
-  if (!headers) return;
-
   group('Post API', () => {
     const listRes = http.get(
       `${BASE_URL}/api/v1/posts?page=0&size=10`,
-      { ...headers, tags: { scenario: 'post_get_load', endpoint: 'post_list', method: 'GET', detail_mode: DETAIL_MODE } }
+      { tags: { scenario: 'post_get_load', endpoint: 'post_list', method: 'GET', detail_mode: DETAIL_MODE } }
     );
     postListDuration.add(listRes.timings.duration);
     const listOk = listChecks(listRes);
@@ -120,7 +106,7 @@ export default function () {
     if (detailId) {
       const detailRes = http.get(
         `${BASE_URL}/api/v1/posts/${detailId}`,
-        { ...headers, tags: { scenario: 'post_get_load', endpoint: 'post_detail', method: 'GET', detail_mode: DETAIL_MODE } }
+        { tags: { scenario: 'post_get_load', endpoint: 'post_detail', method: 'GET', detail_mode: DETAIL_MODE } }
       );
       postDetailDuration.add(detailRes.timings.duration);
       const detailOk = detailChecks(detailRes);

--- a/perf/k6/scripts/post/get-stress-test.js
+++ b/perf/k6/scripts/post/get-stress-test.js
@@ -1,7 +1,7 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Rate, Trend } from 'k6/metrics';
-import { BASE_URL, TEST_USERS, TEST_PASSWORD, login, authHeaders } from '../common.js';
+import { BASE_URL } from '../common.js';
 
 const errorRate = new Rate('errors');
 const postListDuration = new Trend('post_list_duration');
@@ -14,7 +14,6 @@ const HOT_IDS = (__ENV.POST_HOT_IDS || '')
   .filter((v) => Number.isFinite(v) && v > 0);
 const CACHED_ID_SIZE = Math.max(1, Number(__ENV.POST_CACHED_ID_SIZE || 3));
 
-let cachedHeaders = null;
 let cachedPostIds = [];
 
 export const options = {
@@ -38,16 +37,6 @@ export const options = {
     errors: ['rate<0.005'],
   },
 };
-
-function getHeaders() {
-  if (!cachedHeaders) {
-    const username = TEST_USERS[(__VU - 1) % TEST_USERS.length];
-    const credentials = login(username, TEST_PASSWORD);
-    if (!credentials) return null;
-    cachedHeaders = authHeaders(credentials);
-  }
-  return cachedHeaders;
-}
 
 function parseJson(res) {
   try {
@@ -104,13 +93,10 @@ function pickDetailId(listIds) {
 }
 
 export default function () {
-  const headers = getHeaders();
-  if (!headers) return;
-
   group('Post API', () => {
     const listRes = http.get(
       `${BASE_URL}/api/v1/posts?page=0&size=10`,
-      { ...headers, tags: { scenario: 'post_get_stress', endpoint: 'post_list', method: 'GET', detail_mode: DETAIL_MODE } }
+      { tags: { scenario: 'post_get_stress', endpoint: 'post_list', method: 'GET', detail_mode: DETAIL_MODE } }
     );
     postListDuration.add(listRes.timings.duration);
     const listOk = listChecks(listRes);
@@ -122,7 +108,7 @@ export default function () {
     if (detailId) {
       const detailRes = http.get(
         `${BASE_URL}/api/v1/posts/${detailId}`,
-        { ...headers, tags: { scenario: 'post_get_stress', endpoint: 'post_detail', method: 'GET', detail_mode: DETAIL_MODE } }
+        { tags: { scenario: 'post_get_stress', endpoint: 'post_detail', method: 'GET', detail_mode: DETAIL_MODE } }
       );
       postDetailDuration.add(detailRes.timings.duration);
       const detailOk = detailChecks(detailRes);

--- a/perf/k6/scripts/search/load-test.js
+++ b/perf/k6/scripts/search/load-test.js
@@ -2,7 +2,7 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Rate, Trend } from 'k6/metrics';
-import { BASE_URL, TEST_USERS, TEST_PASSWORD, login, authHeaders } from '../common.js';
+import { BASE_URL } from '../common.js';
 
 // 커스텀 메트릭
 const errorRate = new Rate('errors');
@@ -56,26 +56,7 @@ export const options = {
   },
 };
 
-// ── 로그인 & 인증 헤더 (VU당 1회만 로그인, 이후 캐싱) ──
-let cachedHeaders = null;
-let cachedUsername = null;
-
-function getHeaders() {
-  if (!cachedHeaders) {
-    const username = TEST_USERS[(__VU - 1) % TEST_USERS.length];
-    const credentials = login(username, TEST_PASSWORD);
-    if (!credentials) return null;
-
-    cachedUsername = username;
-    cachedHeaders = authHeaders(credentials);
-  }
-  return { headers: cachedHeaders, username: cachedUsername };
-}
-
 export default function () {
-  const headers = getHeaders();
-  if (!headers) return;
-
   const keyword = pickKeyword(); // 키워드를 무작위로 선택
 
   // ── 📌 경매/게시물 검색 API 테스트 ──
@@ -83,7 +64,7 @@ export default function () {
     const start = Date.now();
     const url = `${BASE_URL}/api/v1/search?keyword=${encodeURIComponent(keyword)}&status=OPEN&size=20`;
 
-    const res = http.get(url, { headers, tags: { case: 'search' } });
+    const res = http.get(url, { tags: { case: 'search' } });
 
     check(res, {
       "검색 성공": (r) => r.status === 200,

--- a/perf/k6/scripts/search/smoke-test.js
+++ b/perf/k6/scripts/search/smoke-test.js
@@ -2,7 +2,7 @@
 import http from 'k6/http';
 import { check, sleep, group } from 'k6';
 import { Rate, Trend } from 'k6/metrics';
-import { BASE_URL, TEST_USERS, TEST_PASSWORD, login, authHeaders } from '../common.js';
+import { BASE_URL } from '../common.js';
 
 // 커스텀 메트릭
 const errorRate = new Rate('errors');
@@ -54,26 +54,7 @@ export const options = {
   },
 };
 
-// ── 로그인 & 인증 헤더 (VU당 1회만 로그인, 이후 캐싱) ──
-let cachedHeaders = null;
-let cachedUsername = null;
-
-function getHeaders() {
-  if (!cachedHeaders) {
-    const username = TEST_USERS[(__VU - 1) % TEST_USERS.length];
-    const credentials = login(username, TEST_PASSWORD);
-    if (!credentials) return null;
-
-    cachedUsername = username;
-    cachedHeaders = authHeaders(credentials);
-  }
-  return { headers: cachedHeaders, username: cachedUsername };
-}
-
 export default function () {
-  const headers = getHeaders();
-  if (!headers) return;
-
   const keyword = pickKeyword(); // 키워드를 무작위로 선택
 
   // ── 📌 경매/게시물 검색 API 테스트 ──
@@ -81,7 +62,7 @@ export default function () {
     const start = Date.now();
     const url = `${BASE_URL}/api/v1/search?keyword=${encodeURIComponent(keyword)}&status=OPEN&size=20`;
 
-    const res = http.get(url, { headers, tags: { case: 'search' } });
+    const res = http.get(url, { tags: { case: 'search' } });
 
     check(res, {
       "검색 성공": (r) => r.status === 200,


### PR DESCRIPTION
## 🔗 Issue 번호
- #236

## 🛠 작업 내역
- k6 공통 유틸에 인증 풀 구성/선택 함수 추가
- 인증 필요한 시나리오(`load-test`, `bid/*`, `post/create*`)를 `setup` 1회 로그인 + 반복 구간 토큰 재사용 구조로 전환
- 인증 불필요 시나리오(`auction/get*`, `auction/smoke`, `post/get*`, `search/load|smoke`)에서 로그인/인증 헤더 제거

## 🔄 변경 사항
- `common.js`
  - `login()` 반환값에 `username` 추가
  - `authHeader()`, `buildAuthList()`, `pickAuth()` 추가
- 인증 시나리오
  - `export function setup()` 도입
  - `default(data)`에서 `pickAuth(data.authList)` 사용
- 비인증 조회 시나리오
  - 로그인 호출 및 캐시 인증 헤더 로직 삭제

## ✨ 새로운 기능
- 인증 필요 여부를 시나리오 단위로 분리하여 429 로그인 노이즈를 줄이는 테스트 구조

## 📦 작업 유형
- [ ] 신규 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?