### PR TITLE
[fix/#249] 경매 목록 조회 성능 최적화 (SQL 로그 억제 + 썸네일 조회 경량화)

### DIFF
--- a/src/main/java/com/back/domain/auction/auction/repository/AuctionImageRepository.kt
+++ b/src/main/java/com/back/domain/auction/auction/repository/AuctionImageRepository.kt
@@ -3,7 +3,23 @@ package com.back.domain.auction.auction.repository
 import com.back.domain.auction.auction.entity.AuctionImage
 import com.back.domain.auction.auction.entity.AuctionImageId
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
-interface AuctionImageRepository : JpaRepository<AuctionImage, AuctionImageId>
+interface AuctionImageRepository : JpaRepository<AuctionImage, AuctionImageId> {
+    @Query(
+        """
+        SELECT ai.auction.id AS auctionId, ai.image.url AS thumbnailUrl
+        FROM AuctionImage ai
+        WHERE ai.auction.id IN :auctionIds
+          AND ai.image.id = (
+            SELECT MIN(ai2.image.id)
+            FROM AuctionImage ai2
+            WHERE ai2.auction.id = ai.auction.id
+          )
+        """
+    )
+    fun findThumbnailUrlsByAuctionIds(@Param("auctionIds") auctionIds: Collection<Int>): List<AuctionThumbnailProjection>
+}

--- a/src/main/java/com/back/domain/auction/auction/repository/AuctionThumbnailProjection.kt
+++ b/src/main/java/com/back/domain/auction/auction/repository/AuctionThumbnailProjection.kt
@@ -1,0 +1,6 @@
+package com.back.domain.auction.auction.repository
+
+interface AuctionThumbnailProjection {
+    val auctionId: Int
+    val thumbnailUrl: String
+}

--- a/src/main/java/com/back/domain/auction/auction/service/AuctionService.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/AuctionService.kt
@@ -115,7 +115,8 @@ class AuctionService(
                 auctionPersistencePort.findAll(pageable)
         }
 
-        val dtoPage = auctionPage.map { auction -> AuctionListItemDto(auction, getThumbnailUrl(auction)) }
+        val thumbnailMap = auctionPersistencePort.findThumbnailUrlsByAuctionIds(auctionPage.content.map { it.id })
+        val dtoPage = auctionPage.map { auction -> AuctionListItemDto(auction, thumbnailMap[auction.id]) }
 
         return RsData("200-1", "경매 목록 조회 성공", AuctionPageResponse.from(dtoPage))
     }
@@ -136,7 +137,8 @@ class AuctionService(
             auctionPersistencePort.findBySellerId(userId, pageable)
         }
 
-        val dtoSlice = auctionSlice.map { auction -> AuctionListItemDto(auction, getThumbnailUrl(auction)) }
+        val thumbnailMap = auctionPersistencePort.findThumbnailUrlsByAuctionIds(auctionSlice.content.map { it.id })
+        val dtoSlice = auctionSlice.map { auction -> AuctionListItemDto(auction, thumbnailMap[auction.id]) }
 
         return RsData("200-1", "경매 목록 조회 성공", AuctionSliceResponse.from(dtoSlice))
     }
@@ -163,9 +165,6 @@ class AuctionService(
         }
         return Sort.by(direction, property)
     }
-
-    private fun getThumbnailUrl(auction: Auction): String? =
-        auction.auctionImages.firstOrNull()?.image?.url
 
     @Cacheable(value = ["auction"], key = "#auctionId")
     override fun getAuctionDetailData(auctionId: Int): AuctionDetailResponse {

--- a/src/main/java/com/back/domain/auction/auction/service/adapter/AuctionPersistenceAdapter.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/adapter/AuctionPersistenceAdapter.kt
@@ -2,6 +2,7 @@ package com.back.domain.auction.auction.service.adapter
 
 import com.back.domain.auction.auction.entity.Auction
 import com.back.domain.auction.auction.entity.AuctionStatus
+import com.back.domain.auction.auction.repository.AuctionImageRepository
 import com.back.domain.auction.auction.repository.AuctionRepository
 import com.back.domain.auction.auction.service.port.AuctionPersistencePort
 import org.springframework.data.domain.Page
@@ -12,7 +13,8 @@ import java.time.LocalDateTime
 // JPA 저장소를 AuctionPersistencePort로 감싸 인프라 의존을 어댑터 계층으로 한정한다.
 @Component
 class AuctionPersistenceAdapter(
-    private val auctionRepository: AuctionRepository
+    private val auctionRepository: AuctionRepository,
+    private val auctionImageRepository: AuctionImageRepository
 ) : AuctionPersistencePort {
     override fun save(auction: Auction): Auction = auctionRepository.save(auction)
 
@@ -45,4 +47,10 @@ class AuctionPersistenceAdapter(
 
     override fun findExpiredOpenAuctions(now: LocalDateTime): List<Auction> =
         auctionRepository.findByStatusAndEndAtBefore(AuctionStatus.OPEN, now)
+
+    override fun findThumbnailUrlsByAuctionIds(auctionIds: Collection<Int>): Map<Int, String> {
+        if (auctionIds.isEmpty()) return emptyMap()
+        return auctionImageRepository.findThumbnailUrlsByAuctionIds(auctionIds)
+            .associate { it.auctionId to it.thumbnailUrl }
+    }
 }

--- a/src/main/java/com/back/domain/auction/auction/service/port/AuctionPersistencePort.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/port/AuctionPersistencePort.kt
@@ -19,4 +19,5 @@ interface AuctionPersistencePort {
     fun findByStatus(status: AuctionStatus, pageable: Pageable): Page<Auction>
     fun findByCategoryNameAndStatus(categoryName: String, status: AuctionStatus, pageable: Pageable): Page<Auction>
     fun findExpiredOpenAuctions(now: LocalDateTime): List<Auction>
+    fun findThumbnailUrlsByAuctionIds(auctionIds: Collection<Int>): Map<Int, String>
 }

--- a/src/main/resources/application-loadtest-cloud.yml
+++ b/src/main/resources/application-loadtest-cloud.yml
@@ -34,6 +34,7 @@ spring:
       ddl-auto: validate               # create/update 절대 금지
     properties:
       hibernate:
+        show_sql: false
         format_sql: false
         default_batch_fetch_size: 100
 

--- a/src/main/resources/application-loadtest.yml
+++ b/src/main/resources/application-loadtest.yml
@@ -9,6 +9,7 @@ spring:
       ddl-auto: validate               # create/update 절대 금지
     properties:
       hibernate:
+        show_sql: false
         format_sql: false
         default_batch_fetch_size: 100
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -9,11 +9,13 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
+    show-sql: false
     hibernate:
       ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+        show_sql: false
 
   # Cache 설정 (운영에서는 Redis 미사용)
   cache:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -12,13 +12,18 @@
         <appender-ref ref="CONSOLE" />
     </root>
 
-    <!-- 개발 환경 로그 레벨 -->
-    <logger name="com.back.domain.auction" level="DEBUG" />
-    <logger name="com.back.domain.bid" level="DEBUG" />
-    <logger name="com.back.global.initData" level="INFO" />
+    <!-- 개발 환경에서만 상세 SQL 로그를 허용한다. -->
+    <springProfile name="dev">
+        <logger name="com.back.domain.auction" level="DEBUG" />
+        <logger name="com.back.domain.bid" level="DEBUG" />
+        <logger name="com.back.global.initData" level="INFO" />
+        <logger name="org.hibernate.SQL" level="DEBUG" />
+        <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE" />
+    </springProfile>
 
-    <!-- Hibernate SQL 로그 -->
-    <logger name="org.hibernate.SQL" level="DEBUG" />
-    <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE" />
+    <!-- loadtest/prod 등 비개발 환경에서는 SQL 바인딩 로그를 차단한다. -->
+    <springProfile name="!dev">
+        <logger name="org.hibernate.SQL" level="WARN" />
+        <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="WARN" />
+    </springProfile>
 </configuration>
-


### PR DESCRIPTION
## 작업 내용
- 비개발 프로파일에서 Hibernate SQL/바인딩 로그를 `WARN`으로 낮춰 로깅 오버헤드를 줄였습니다.
- 경매 목록 조회 시 썸네일을 `auction.auctionImages` 엔티티 접근 대신 배치 조회 쿼리로 가져오도록 변경했습니다.
- `AuctionPersistencePort`/`AuctionPersistenceAdapter`에 썸네일 맵 조회 계약 및 구현을 추가했습니다.

## 기대 효과
- 부하 상황에서 과도한 SQL 로그 출력으로 인한 I/O/CPU 오버헤드 감소
- 경매 목록 조회 시 이미지 접근 비용 감소 및 응답 지연 완화

## 검증
- `./gradlew compileKotlin --no-daemon` 성공