### PR TITLE
[Refactor] 채팅 도메인 부하 테스트 후 최적화

### DIFF
--- a/src/main/java/com/back/domain/chat/chat/dto/response/ChatResponse.kt
+++ b/src/main/java/com/back/domain/chat/chat/dto/response/ChatResponse.kt
@@ -15,7 +15,30 @@ data class ChatResponse(
     val read: Boolean,
 ) {
     companion object {
-        fun from(chat: Chat, senderProfileImageUrl: String? = null): ChatResponse {
+        fun from(
+            chat: Chat,
+            roomId: String,
+            itemId: Int?,
+            senderProfileImageUrl: String? = null,
+            readOverride: Boolean? = null,
+        ): ChatResponse =
+            ChatResponse(
+                id = chat.id,
+                itemId = itemId,
+                roomId = roomId,
+                senderId = chat.senderId,
+                senderProfileImageUrl = senderProfileImageUrl,
+                message = chat.message,
+                createDate = chat.createDate,
+                imageUrls = chat.chatImages.map { it.image.url },
+                read = readOverride ?: chat.read,
+            )
+
+        fun from(
+            chat: Chat,
+            senderProfileImageUrl: String? = null,
+            readOverride: Boolean? = null,
+        ): ChatResponse {
             val room = chat.chatRoom
 
             return ChatResponse(
@@ -27,7 +50,7 @@ data class ChatResponse(
                 message = chat.message,
                 createDate = chat.createDate,
                 imageUrls = chat.chatImages.map { it.image.url },
-                read = chat.read,
+                read = readOverride ?: chat.read,
             )
         }
     }

--- a/src/main/java/com/back/domain/chat/chat/entity/Chat.kt
+++ b/src/main/java/com/back/domain/chat/chat/entity/Chat.kt
@@ -5,12 +5,19 @@ import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
+import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 
-@Table(name = "chat")
+@Table(
+    name = "chat",
+    indexes = [
+        Index(name = "idx_chat_room_id_id", columnList = "room_id, id"),
+        Index(name = "idx_chat_room_read_sender", columnList = "room_id, is_read, sender_id"),
+    ],
+)
 @Entity
 class Chat() : BaseEntity() {
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/back/domain/chat/chat/entity/ChatRoom.kt
+++ b/src/main/java/com/back/domain/chat/chat/entity/ChatRoom.kt
@@ -6,6 +6,14 @@ import java.time.LocalDateTime
 import java.util.*
 
 @Entity
+@Table(
+    name = "chat_room",
+    indexes = [
+        Index(name = "idx_chat_room_tx_item_buyer_deleted", columnList = "tx_type, item_id, buyer_api_key, deleted"),
+        Index(name = "idx_chat_room_seller_active", columnList = "seller_api_key, seller_exited, deleted"),
+        Index(name = "idx_chat_room_buyer_active", columnList = "buyer_api_key, buyer_exited, deleted"),
+    ],
+)
 class ChatRoom (
     @Column(unique = true, nullable = false)
     var roomId: String = "",

--- a/src/main/java/com/back/domain/chat/chat/repository/ChatRepository.kt
+++ b/src/main/java/com/back/domain/chat/chat/repository/ChatRepository.kt
@@ -2,7 +2,7 @@ package com.back.domain.chat.chat.repository
 
 import com.back.domain.chat.chat.dto.response.UnreadCountResponse
 import com.back.domain.chat.chat.entity.Chat
-import org.springframework.data.jpa.repository.EntityGraph
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -14,7 +14,26 @@ interface ChatRepository : JpaRepository<Chat, Int> {
     @Query("UPDATE Chat c SET c.read = true WHERE c.chatRoom.roomId = :roomId AND c.senderId != :readerId AND c.read = false")
     fun markMessagesAsRead(@Param("roomId") roomId: String, @Param("readerId") readerId: Int): Int
 
-    // 내 채팅방의 최신 메시지 조회 + 방 정보 + 상품 정보 (JPQL)
+    // 조회된 메시지 id 집합만 읽음 처리 (방 전체 스캔 방지)
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Chat c SET c.read = true WHERE c.id IN :chatIds AND c.read = false")
+    fun markMessagesAsReadByIds(@Param("chatIds") chatIds: List<Int>): Int
+
+    // 내 채팅방의 최신 메시지 id만 조회
+    @Query(
+        "SELECT c.id FROM Chat c " +
+                "JOIN c.chatRoom cr " +
+                "WHERE cr.deleted = false " +
+                "AND ((cr.sellerApiKey = :apiKey AND cr.sellerExited = false) " +
+                "OR (cr.buyerApiKey = :apiKey AND cr.buyerExited = false)) " +
+                "AND c.id = (" +
+                "SELECT MAX(c2.id) FROM Chat c2 WHERE c2.chatRoom.roomId = cr.roomId" +
+                ") " +
+                "ORDER BY c.createDate DESC",
+    )
+    fun findLatestChatIdsByMember(@Param("apiKey") apiKey: String): List<Int>
+
+    // 테스트/기존 호출 호환용 (서비스 핵심 경로에서는 ID 조회 + 재조회 방식 사용)
     @Query(
         "SELECT c FROM Chat c " +
                 "JOIN FETCH c.chatRoom cr " +
@@ -23,7 +42,7 @@ interface ChatRepository : JpaRepository<Chat, Int> {
                 "WHERE c2.chatRoom.deleted = false " +
                 "AND ((c2.chatRoom.sellerApiKey = :apiKey AND c2.chatRoom.sellerExited = false) " +
                 "OR (c2.chatRoom.buyerApiKey = :apiKey AND c2.chatRoom.buyerExited = false)) " +
-                "GROUP BY c2.chatRoom" +
+                "GROUP BY c2.chatRoom.roomId" +
                 ") " +
                 "ORDER BY c.createDate DESC",
     )
@@ -40,14 +59,41 @@ interface ChatRepository : JpaRepository<Chat, Int> {
     )
     fun countUnreadMessagesByRoomIds(@Param("roomIds") roomIds: List<String>, @Param("memberId") memberId: Int): List<UnreadCountResponse>
 
+    @Query(
+        "SELECT COUNT(c) FROM Chat c " +
+                "WHERE c.chatRoom.roomId = :roomId " +
+                "AND c.read = false " +
+                "AND c.senderId != :memberId",
+    )
+    fun countUnreadMessagesByRoomId(@Param("roomId") roomId: String, @Param("memberId") memberId: Int): Long
+
 
     // 최신 메세지 20개만 가져오기 (내림차순)
-    @EntityGraph(attributePaths = ["chatRoom"])
-    fun findTop20ByChatRoom_RoomIdOrderByIdDesc(roomId: String): List<Chat>
+    @Query("SELECT c.id FROM Chat c WHERE c.chatRoom.roomId = :roomId ORDER BY c.id DESC")
+    fun findTopIdsByRoomId(@Param("roomId") roomId: String, pageable: Pageable): List<Int>
 
     // 과거 내역을 부르는 경우: lastChatId 보다 작은 메세지 20개 (내림차순)
-    @EntityGraph(attributePaths = ["chatRoom"])
-    fun findTop20ByChatRoom_RoomIdAndIdLessThanOrderByIdDesc(roomId: String, lastId: Int): List<Chat>
+    @Query("SELECT c.id FROM Chat c WHERE c.chatRoom.roomId = :roomId AND c.id < :lastId ORDER BY c.id DESC")
+    fun findTopIdsByRoomIdAndIdLessThan(
+        @Param("roomId") roomId: String,
+        @Param("lastId") lastId: Int,
+        pageable: Pageable,
+    ): List<Int>
+
+    @Query(
+        "SELECT c FROM Chat c " +
+                "WHERE c.id IN :chatIds " +
+                "ORDER BY c.id DESC",
+    )
+    fun findChatsByIds(@Param("chatIds") chatIds: List<Int>): List<Chat>
+
+    @Query(
+        "SELECT c FROM Chat c " +
+                "JOIN FETCH c.chatRoom cr " +
+                "WHERE c.id IN :chatIds " +
+                "ORDER BY c.id DESC",
+    )
+    fun findChatsWithRoomByIds(@Param("chatIds") chatIds: List<Int>): List<Chat>
 
     @Modifying
     @Query("DELETE FROM Chat c WHERE c.chatRoom.roomId = :roomId")

--- a/src/main/java/com/back/domain/chat/chat/service/ChatService.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/ChatService.kt
@@ -22,6 +22,7 @@ import com.back.global.exception.ServiceException
 import com.back.global.rq.Rq
 import com.back.global.rsData.RsData
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -39,6 +40,8 @@ class ChatService(
     private val chatPublishPort: ChatPublishPort,
     private val rq: Rq,
     private val eventPublisher: ApplicationEventPublisher,
+    @Value("\${chat.events.async-enabled:true}")
+    private val asyncEventsEnabled: Boolean,
 ) {
     private val memberCache = ConcurrentHashMap<Int, CachedCurrentMember>()
 
@@ -130,25 +133,46 @@ class ChatService(
         val persistedMessage = chatPersistencePort.saveChat(chatMessage)
 
         val chatResponse = ChatResponse.from(persistedMessage, sender.profileImageUrl)
-        eventPublisher.publishEvent(
-            ChatMessageCommittedEvent(
-                roomId = roomId,
-                senderId = sender.id,
-                senderApiKey = sender.apiKey,
-                senderNickname = sender.nickname,
-                senderProfileImageUrl = sender.profileImageUrl,
-                txType = room.txType,
-                itemId = room.itemId,
-                itemName = room.itemName,
-                itemImageUrl = room.itemImageUrl,
-                itemPrice = room.itemPrice,
-                sellerApiKey = room.sellerApiKey,
-                buyerApiKey = room.buyerApiKey,
-                message = req.message,
-                messageDate = persistedMessage.createDate,
-                roomMessagePayload = chatResponse,
-            ),
-        )
+        if (asyncEventsEnabled) {
+            eventPublisher.publishEvent(
+                ChatMessageCommittedEvent(
+                    roomId = roomId,
+                    senderId = sender.id,
+                    senderApiKey = sender.apiKey,
+                    senderNickname = sender.nickname,
+                    senderProfileImageUrl = sender.profileImageUrl,
+                    txType = room.txType,
+                    itemId = room.itemId,
+                    itemName = room.itemName,
+                    itemImageUrl = room.itemImageUrl,
+                    itemPrice = room.itemPrice,
+                    sellerApiKey = room.sellerApiKey,
+                    buyerApiKey = room.buyerApiKey,
+                    message = req.message,
+                    messageDate = persistedMessage.createDate,
+                    roomMessagePayload = chatResponse,
+                ),
+            )
+        } else {
+            val opponentApiKey = if (room.sellerApiKey == sender.apiKey) room.buyerApiKey else room.sellerApiKey
+            runMessagingSafely(
+                onSuccess = { log.info("메시지 브로드캐스팅 성공 - RoomID: {}, MessageID: {}", roomId, persistedMessage.id) },
+                onFailure = { e -> log.error("WebSocket 전송 실패 - RoomID: {}, Error: {}", roomId, e.message) },
+            ) {
+                chatPublishPort.publishRoomMessage(roomId, chatResponse)
+            }
+
+            chatMemberPort.findMemberByApiKey(opponentApiKey)?.let { opponent ->
+                sendUserNotification(
+                    type = "NEW_MESSAGE",
+                    room = room,
+                    recipient = opponent,
+                    opponent = sender,
+                    message = req.message,
+                    messageDate = persistedMessage.createDate,
+                )
+            }
+        }
 
         return RsData("200-1", "메시지가 전송되었습니다.", ChatIdResponse(persistedMessage.id))
     }
@@ -169,13 +193,22 @@ class ChatService(
 
         val updatedCount = if (unreadMessageIds.isEmpty()) 0 else chatPersistencePort.markMessagesAsReadByIds(unreadMessageIds)
         if (updatedCount > 0) {
-            eventPublisher.publishEvent(
-                ChatRoomReadEvent(
-                    roomId = roomId,
-                    readerId = me.id,
-                    updatedCount = updatedCount,
-                ),
-            )
+            if (asyncEventsEnabled) {
+                eventPublisher.publishEvent(
+                    ChatRoomReadEvent(
+                        roomId = roomId,
+                        readerId = me.id,
+                        updatedCount = updatedCount,
+                    ),
+                )
+            } else {
+                val readNotification: Any = mapOf(
+                    "readerId" to me.id,
+                    "roomId" to roomId,
+                )
+                chatPublishPort.publishRoomRead(roomId, readNotification)
+                log.debug("읽음 알림 전송 - RoomId: {}, ReaderId: {}, UpdatedCount: {}", roomId, me.id, updatedCount)
+            }
         }
 
         val membersByApiKey = chatMemberPort.findMembersByApiKeys(setOf(room.sellerApiKey, room.buyerApiKey))

--- a/src/main/java/com/back/domain/chat/chat/service/ChatService.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/ChatService.kt
@@ -9,6 +9,8 @@ import com.back.domain.chat.chat.dto.response.ChatRoomListResponse
 import com.back.domain.chat.chat.entity.Chat
 import com.back.domain.chat.chat.entity.ChatRoom
 import com.back.domain.chat.chat.entity.ChatRoomType
+import com.back.domain.chat.chat.service.event.ChatMessageCommittedEvent
+import com.back.domain.chat.chat.service.event.ChatRoomReadEvent
 import com.back.domain.chat.chat.service.port.ChatItemPort
 import com.back.domain.chat.chat.service.port.ChatMemberInfo
 import com.back.domain.chat.chat.service.port.ChatMemberPort
@@ -20,10 +22,12 @@ import com.back.global.exception.ServiceException
 import com.back.global.rq.Rq
 import com.back.global.rsData.RsData
 import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 
 @Service
 @Transactional(readOnly = true)
@@ -34,7 +38,10 @@ class ChatService(
     private val chatMediaPort: ChatMediaPort,
     private val chatPublishPort: ChatPublishPort,
     private val rq: Rq,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
+    private val memberCache = ConcurrentHashMap<Int, CachedCurrentMember>()
+
     @Transactional
     fun createChatRoom(itemId: Int, txType: String): RsData<ChatRoomIdResponse> {
         val type = parseTxType(txType)
@@ -105,13 +112,11 @@ class ChatService(
         val sender = currentMemberFromDb()
         requireChatParticipant(room, sender.apiKey)
 
-        val chatMessage = chatPersistencePort.saveChat(
-            Chat(
-                chatRoom = room,
-                senderId = sender.id,
-                message = req.message,
-                read = false,
-            ),
+        val chatMessage = Chat(
+            chatRoom = room,
+            senderId = sender.id,
+            message = req.message,
+            read = false,
         )
 
         val uploadFiles = req.images.orEmpty().map {
@@ -122,29 +127,30 @@ class ChatService(
             )
         }
         chatMediaPort.saveChatImages(chatMessage, uploadFiles)
-        chatPersistencePort.saveChat(chatMessage)
+        val persistedMessage = chatPersistencePort.saveChat(chatMessage)
 
-        val chatResponse = ChatResponse.from(chatMessage, sender.profileImageUrl)
-        runMessagingSafely(
-            onSuccess = { log.info("메시지 브로드캐스팅 성공 - RoomID: {}, MessageID: {}", roomId, chatMessage.id) },
-            onFailure = { e -> log.error("WebSocket 전송 실패 - RoomID: {}, Error: {}", roomId, e.message) },
-        ) {
-            chatPublishPort.publishRoomMessage(roomId, chatResponse)
-        }
-
-        val opponentApiKey = if (room.sellerApiKey == sender.apiKey) room.buyerApiKey else room.sellerApiKey
-        chatMemberPort.findMemberByApiKey(opponentApiKey)?.let { opponent ->
-            sendUserNotification(
-                type = "NEW_MESSAGE",
-                room = room,
-                recipient = opponent,
-                opponent = sender,
+        val chatResponse = ChatResponse.from(persistedMessage, sender.profileImageUrl)
+        eventPublisher.publishEvent(
+            ChatMessageCommittedEvent(
+                roomId = roomId,
+                senderId = sender.id,
+                senderApiKey = sender.apiKey,
+                senderNickname = sender.nickname,
+                senderProfileImageUrl = sender.profileImageUrl,
+                txType = room.txType,
+                itemId = room.itemId,
+                itemName = room.itemName,
+                itemImageUrl = room.itemImageUrl,
+                itemPrice = room.itemPrice,
+                sellerApiKey = room.sellerApiKey,
+                buyerApiKey = room.buyerApiKey,
                 message = req.message,
-                messageDate = chatMessage.createDate,
-            )
-        }
+                messageDate = persistedMessage.createDate,
+                roomMessagePayload = chatResponse,
+            ),
+        )
 
-        return RsData("200-1", "메시지가 전송되었습니다.", ChatIdResponse(chatMessage.id))
+        return RsData("200-1", "메시지가 전송되었습니다.", ChatIdResponse(persistedMessage.id))
     }
 
     @Transactional
@@ -154,28 +160,36 @@ class ChatService(
         val me = currentMemberFromDb()
         requireChatParticipant(room, me.apiKey)
 
-        val updatedCount = chatPersistencePort.markMessagesAsRead(roomId, me.id)
+        val chats = chatPersistencePort.findRecentChats(roomId, lastChatId)
+        val unreadMessageIds = chats.asSequence()
+            .filter { !it.read && it.senderId != me.id }
+            .map { it.id }
+            .toList()
+        val unreadMessageIdSet = unreadMessageIds.toSet()
+
+        val updatedCount = if (unreadMessageIds.isEmpty()) 0 else chatPersistencePort.markMessagesAsReadByIds(unreadMessageIds)
         if (updatedCount > 0) {
-            val readNotification: Any = mapOf(
-                "readerId" to me.id,
-                "roomId" to roomId,
+            eventPublisher.publishEvent(
+                ChatRoomReadEvent(
+                    roomId = roomId,
+                    readerId = me.id,
+                    updatedCount = updatedCount,
+                ),
             )
-            chatPublishPort.publishRoomRead(roomId, readNotification)
-            log.debug("읽음 알림 전송 - RoomId: {}, ReaderId: {}, UpdatedCount: {}", roomId, me.id, updatedCount)
         }
 
-        val seller = chatMemberPort.findMemberByApiKey(room.sellerApiKey)
-        val buyer = chatMemberPort.findMemberByApiKey(room.buyerApiKey)
-
-        val chats = chatPersistencePort.findRecentChats(roomId, lastChatId)
+        val membersByApiKey = chatMemberPort.findMembersByApiKeys(setOf(room.sellerApiKey, room.buyerApiKey))
+        val profileByMemberId = membersByApiKey.values.associateBy({ it.id }, { it.profileImageUrl })
 
         val responses = chats.asReversed().map { chat ->
-            val senderProfile = when (chat.senderId) {
-                seller?.id -> seller.profileImageUrl
-                buyer?.id -> buyer.profileImageUrl
-                else -> null
-            }
-            ChatResponse.from(chat, senderProfile)
+            val senderProfile = profileByMemberId[chat.senderId]
+            ChatResponse.from(
+                chat = chat,
+                roomId = room.roomId,
+                itemId = room.itemId,
+                senderProfileImageUrl = senderProfile,
+                readOverride = chat.read || unreadMessageIdSet.contains(chat.id),
+            )
         }
 
         return RsData("200-1", "메시지 조회 성공", responses)
@@ -257,12 +271,10 @@ class ChatService(
             onSuccess = { log.info("개인 알림 전송 - Type: {}, Recipient: {}, RoomID: {}", type, recipient.id, room.roomId) },
             onFailure = { e -> log.error("개인 알림 전송 실패 - Recipient: {}, Error: {}", recipient.id, e.message) },
         ) {
-            val unreadCount = chatPersistencePort
-                .countUnreadMessagesByRoomIds(listOf(room.roomId), recipient.id)
-                .firstOrNull()
-                ?.count
-                ?.toInt()
-                ?: 0
+            val unreadCount = when (type) {
+                "NEW_ROOM" -> 0
+                else -> chatPersistencePort.countUnreadMessagesByRoomId(room.roomId, recipient.id)
+            }
 
             val notification = ChatNotification(
                 type = type,
@@ -296,7 +308,18 @@ class ChatService(
 
     private fun currentMemberFromDb(): ChatMemberInfo {
         val actor = rq.actor ?: throw ServiceException("401-1", "로그인이 필요합니다.")
-        return chatMemberPort.getMemberOrThrow(actor.id)
+        val now = System.currentTimeMillis()
+
+        memberCache[actor.id]
+            ?.takeIf { it.expiresAtMillis > now }
+            ?.let { return it.member }
+
+        return chatMemberPort.getMemberOrThrow(actor.id).also { fetched ->
+            memberCache[actor.id] = CachedCurrentMember(
+                member = fetched,
+                expiresAtMillis = now + CURRENT_MEMBER_CACHE_TTL_MILLIS,
+            )
+        }
     }
 
     private fun findActiveRoom(roomId: String): ChatRoom =
@@ -330,5 +353,11 @@ class ChatService(
 
     companion object {
         private val log = LoggerFactory.getLogger(ChatService::class.java)
+        private const val CURRENT_MEMBER_CACHE_TTL_MILLIS = 60_000L
     }
+
+    private data class CachedCurrentMember(
+        val member: ChatMemberInfo,
+        val expiresAtMillis: Long,
+    )
 }

--- a/src/main/java/com/back/domain/chat/chat/service/adapter/ChatMediaAdapter.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/adapter/ChatMediaAdapter.kt
@@ -8,6 +8,8 @@ import com.back.domain.image.image.entity.Image
 import com.back.domain.image.image.repository.ImageRepository
 import com.back.global.storage.port.FileStoragePort
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 import java.io.ByteArrayInputStream
 import java.io.InputStream
@@ -22,6 +24,7 @@ class ChatMediaAdapter(
     private val imageRepository: ImageRepository,
 ) : ChatMediaPort {
     /** 비어있지 않은 파일만 처리해 메시지 이미지로 연결한다. */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     override fun saveChatImages(chat: Chat, files: List<ChatUploadFile>) {
         files.filterNot { it.isEmpty }
             .forEach { upload ->

--- a/src/main/java/com/back/domain/chat/chat/service/adapter/ChatMemberAdapter.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/adapter/ChatMemberAdapter.kt
@@ -5,6 +5,7 @@ import com.back.domain.chat.chat.service.port.ChatMemberPort
 import com.back.domain.member.member.repository.MemberRepository
 import com.back.global.exception.ServiceException
 import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * ChatMemberPort 구현체.
@@ -14,21 +15,67 @@ import org.springframework.stereotype.Component
 class ChatMemberAdapter(
     private val memberRepository: MemberRepository,
 ) : ChatMemberPort {
+    private val memberByIdCache = ConcurrentHashMap<Int, CachedMember>()
+    private val memberByApiKeyCache = ConcurrentHashMap<String, CachedMember>()
+
     /** 회원 ID로 회원을 조회한다. */
     override fun getMemberOrThrow(memberId: Int): ChatMemberInfo =
-        memberRepository.findById(memberId)
-            .map { it.toInfo() }
-            .orElseThrow { ServiceException("404-1", "존재하지 않는 회원입니다.") }
+        getCachedMemberById(memberId)
+            ?: memberRepository.findById(memberId)
+                .map { it.toInfo() }
+                .orElseThrow { ServiceException("404-1", "존재하지 않는 회원입니다.") }
+                .also(::cacheMember)
 
     /** apiKey로 회원을 조회한다. */
     override fun findMemberByApiKey(apiKey: String): ChatMemberInfo? =
-        memberRepository.findByApiKey(apiKey).orElse(null)?.toInfo()
+        getCachedMemberByApiKey(apiKey)
+            ?: memberRepository.findByApiKey(apiKey).orElse(null)?.toInfo()?.also(::cacheMember)
 
     /** apiKey 집합으로 회원 목록을 조회해 맵으로 반환한다. */
     override fun findMembersByApiKeys(apiKeys: Set<String>): Map<String, ChatMemberInfo> =
-        memberRepository.findByApiKeyIn(apiKeys.toMutableSet())
-            .map { it.toInfo() }
+        apiKeys.mapNotNull { key -> getCachedMemberByApiKey(key) }
             .associateBy { it.apiKey }
+            .let { cached ->
+                val missingApiKeys = apiKeys - cached.keys
+                if (missingApiKeys.isEmpty()) return cached
+
+                val fetched = memberRepository.findByApiKeyIn(missingApiKeys.toMutableSet())
+                    .map { it.toInfo().also(::cacheMember) }
+                    .associateBy { it.apiKey }
+
+                cached + fetched
+            }
+
+    private fun getCachedMemberById(memberId: Int): ChatMemberInfo? {
+        val now = System.currentTimeMillis()
+        val cached = memberByIdCache[memberId] ?: return null
+        if (cached.expiresAtMillis <= now) {
+            memberByIdCache.remove(memberId)
+            memberByApiKeyCache.remove(cached.member.apiKey)
+            return null
+        }
+        return cached.member
+    }
+
+    private fun getCachedMemberByApiKey(apiKey: String): ChatMemberInfo? {
+        val now = System.currentTimeMillis()
+        val cached = memberByApiKeyCache[apiKey] ?: return null
+        if (cached.expiresAtMillis <= now) {
+            memberByApiKeyCache.remove(apiKey)
+            memberByIdCache.remove(cached.member.id)
+            return null
+        }
+        return cached.member
+    }
+
+    private fun cacheMember(member: ChatMemberInfo) {
+        val cached = CachedMember(
+            member = member,
+            expiresAtMillis = System.currentTimeMillis() + MEMBER_CACHE_TTL_MILLIS,
+        )
+        memberByIdCache[member.id] = cached
+        memberByApiKeyCache[member.apiKey] = cached
+    }
 
     private fun com.back.domain.member.member.entity.Member.toInfo(): ChatMemberInfo =
         ChatMemberInfo(
@@ -38,4 +85,13 @@ class ChatMemberAdapter(
             apiKey = apiKey ?: throw ServiceException("500-1", "회원 apiKey가 없습니다."),
             reputationScore = reputation?.score,
         )
+
+    private data class CachedMember(
+        val member: ChatMemberInfo,
+        val expiresAtMillis: Long,
+    )
+
+    companion object {
+        private const val MEMBER_CACHE_TTL_MILLIS = 60_000L
+    }
 }

--- a/src/main/java/com/back/domain/chat/chat/service/adapter/ChatPersistenceAdapter.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/adapter/ChatPersistenceAdapter.kt
@@ -7,6 +7,7 @@ import com.back.domain.chat.chat.entity.ChatRoomType
 import com.back.domain.chat.chat.repository.ChatRepository
 import com.back.domain.chat.chat.repository.ChatRoomRepository
 import com.back.domain.chat.chat.service.port.ChatPersistencePort
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
 
 /**
@@ -31,17 +32,31 @@ class ChatPersistenceAdapter(
     override fun markMessagesAsRead(roomId: String, readerId: Int): Int =
         chatRepository.markMessagesAsRead(roomId, readerId)
 
+    override fun markMessagesAsReadByIds(chatIds: List<Int>): Int =
+        chatRepository.markMessagesAsReadByIds(chatIds)
+
     override fun findLatestChatsByMember(apiKey: String): List<Chat> =
-        chatRepository.findAllLatestChatsByMember(apiKey)
+        chatRepository.findLatestChatIdsByMember(apiKey)
+            .let { chatIds ->
+                if (chatIds.isEmpty()) emptyList() else chatRepository.findChatsWithRoomByIds(chatIds)
+            }
 
     override fun countUnreadMessagesByRoomIds(roomIds: List<String>, memberId: Int): List<UnreadCountResponse> =
         chatRepository.countUnreadMessagesByRoomIds(roomIds, memberId)
 
+    override fun countUnreadMessagesByRoomId(roomId: String, memberId: Int): Int =
+        chatRepository.countUnreadMessagesByRoomId(roomId, memberId).toInt()
+
     override fun findRecentChats(roomId: String, lastChatId: Int?): List<Chat> =
         if (lastChatId == null || lastChatId <= 0) {
-            chatRepository.findTop20ByChatRoom_RoomIdOrderByIdDesc(roomId)
+            val chatIds = chatRepository.findTopIdsByRoomId(roomId, TOP20)
+            if (chatIds.isEmpty()) emptyList() else chatRepository.findChatsByIds(chatIds)
         } else {
-            chatRepository.findTop20ByChatRoom_RoomIdAndIdLessThanOrderByIdDesc(roomId, lastChatId)
+            val chatIds = chatRepository.findTopIdsByRoomIdAndIdLessThan(roomId, lastChatId, TOP20)
+            if (chatIds.isEmpty()) emptyList() else chatRepository.findChatsByIds(chatIds)
         }
-}
 
+    companion object {
+        private val TOP20 = PageRequest.of(0, 20)
+    }
+}

--- a/src/main/java/com/back/domain/chat/chat/service/adapter/ChatRoomAccessAdapter.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/adapter/ChatRoomAccessAdapter.kt
@@ -5,6 +5,7 @@ import com.back.domain.chat.chat.service.port.ChatRoomAccessInfo
 import com.back.domain.chat.chat.service.port.ChatRoomAccessPort
 import com.back.global.exception.ServiceException
 import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * ChatRoomAccessPort 구현체.
@@ -14,7 +15,14 @@ import org.springframework.stereotype.Component
 class ChatRoomAccessAdapter(
     private val chatRoomRepository: ChatRoomRepository,
 ) : ChatRoomAccessPort {
+    private val roomCache = ConcurrentHashMap<String, CachedRoom>()
+
     override fun getActiveRoomOrThrow(roomId: String): ChatRoomAccessInfo {
+        val now = System.currentTimeMillis()
+        roomCache[roomId]
+            ?.takeIf { it.expiresAtMillis > now }
+            ?.let { return it.info }
+
         val room = chatRoomRepository.findByRoomIdAndDeletedFalse(roomId)
             ?: throw ServiceException("404-1", "존재하지 않는 채팅방입니다.")
 
@@ -22,7 +30,20 @@ class ChatRoomAccessAdapter(
             roomId = room.roomId,
             sellerApiKey = room.sellerApiKey,
             buyerApiKey = room.buyerApiKey,
-        )
+        ).also { info ->
+            roomCache[roomId] = CachedRoom(
+                info = info,
+                expiresAtMillis = now + ROOM_CACHE_TTL_MILLIS,
+            )
+        }
+    }
+
+    private data class CachedRoom(
+        val info: ChatRoomAccessInfo,
+        val expiresAtMillis: Long,
+    )
+
+    companion object {
+        private const val ROOM_CACHE_TTL_MILLIS = 60_000L
     }
 }
-

--- a/src/main/java/com/back/domain/chat/chat/service/event/ChatMessageCommittedEvent.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/event/ChatMessageCommittedEvent.kt
@@ -1,0 +1,23 @@
+package com.back.domain.chat.chat.service.event
+
+import com.back.domain.chat.chat.dto.response.ChatResponse
+import com.back.domain.chat.chat.entity.ChatRoomType
+import java.time.LocalDateTime
+
+data class ChatMessageCommittedEvent(
+    val roomId: String,
+    val senderId: Int,
+    val senderApiKey: String,
+    val senderNickname: String,
+    val senderProfileImageUrl: String?,
+    val txType: ChatRoomType,
+    val itemId: Int?,
+    val itemName: String?,
+    val itemImageUrl: String?,
+    val itemPrice: Int?,
+    val sellerApiKey: String,
+    val buyerApiKey: String,
+    val message: String?,
+    val messageDate: LocalDateTime?,
+    val roomMessagePayload: ChatResponse,
+)

--- a/src/main/java/com/back/domain/chat/chat/service/event/ChatMessageCommittedEventHandler.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/event/ChatMessageCommittedEventHandler.kt
@@ -1,0 +1,52 @@
+package com.back.domain.chat.chat.service.event
+
+import com.back.domain.chat.chat.dto.response.ChatNotification
+import com.back.domain.chat.chat.service.port.ChatMemberPort
+import com.back.domain.chat.chat.service.port.ChatPersistencePort
+import com.back.domain.chat.chat.service.port.ChatPublishPort
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class ChatMessageCommittedEventHandler(
+    private val chatPublishPort: ChatPublishPort,
+    private val chatMemberPort: ChatMemberPort,
+    private val chatPersistencePort: ChatPersistencePort,
+) {
+    @Async("chatTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: ChatMessageCommittedEvent) {
+        runCatching {
+            chatPublishPort.publishRoomMessage(event.roomId, event.roomMessagePayload)
+            val opponentApiKey = if (event.sellerApiKey == event.senderApiKey) event.buyerApiKey else event.sellerApiKey
+            val opponent = chatMemberPort.findMemberByApiKey(opponentApiKey) ?: return
+
+            val unreadCount = chatPersistencePort.countUnreadMessagesByRoomId(event.roomId, opponent.id)
+            val notification = ChatNotification(
+                type = "NEW_MESSAGE",
+                roomId = event.roomId,
+                opponentId = event.senderId,
+                opponentNickname = event.senderNickname,
+                opponentProfileImageUrl = event.senderProfileImageUrl,
+                lastMessage = event.message,
+                lastMessageDate = event.messageDate,
+                unreadCount = unreadCount,
+                itemId = event.itemId,
+                itemName = event.itemName,
+                itemImageUrl = event.itemImageUrl,
+                itemPrice = event.itemPrice,
+                txType = event.txType,
+            )
+            chatPublishPort.publishUserNotification(opponent.id, notification)
+        }.onFailure { e ->
+            log.warn("메시지 후속 비동기 처리 실패 - RoomId: {}, Error: {}", event.roomId, e.message)
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(ChatMessageCommittedEventHandler::class.java)
+    }
+}

--- a/src/main/java/com/back/domain/chat/chat/service/event/ChatRoomReadEvent.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/event/ChatRoomReadEvent.kt
@@ -1,0 +1,7 @@
+package com.back.domain.chat.chat.service.event
+
+data class ChatRoomReadEvent(
+    val roomId: String,
+    val readerId: Int,
+    val updatedCount: Int,
+)

--- a/src/main/java/com/back/domain/chat/chat/service/event/ChatRoomReadEventHandler.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/event/ChatRoomReadEventHandler.kt
@@ -1,0 +1,44 @@
+package com.back.domain.chat.chat.service.event
+
+import com.back.domain.chat.chat.service.port.ChatPublishPort
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class ChatRoomReadEventHandler(
+    private val chatPublishPort: ChatPublishPort,
+) {
+    @Async("chatTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: ChatRoomReadEvent) {
+        val readNotification: Any = mapOf(
+            "readerId" to event.readerId,
+            "roomId" to event.roomId,
+        )
+
+        runCatching { chatPublishPort.publishRoomRead(event.roomId, readNotification) }
+            .onSuccess {
+                log.debug(
+                    "읽음 알림 비동기 전송 - RoomId: {}, ReaderId: {}, UpdatedCount: {}",
+                    event.roomId,
+                    event.readerId,
+                    event.updatedCount,
+                )
+            }
+            .onFailure { e ->
+                log.warn(
+                    "읽음 알림 비동기 전송 실패 - RoomId: {}, ReaderId: {}, Error: {}",
+                    event.roomId,
+                    event.readerId,
+                    e.message,
+                )
+            }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(ChatRoomReadEventHandler::class.java)
+    }
+}

--- a/src/main/java/com/back/domain/chat/chat/service/port/ChatPersistencePort.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/port/ChatPersistencePort.kt
@@ -20,10 +20,13 @@ interface ChatPersistencePort {
 
     fun markMessagesAsRead(roomId: String, readerId: Int): Int
 
+    fun markMessagesAsReadByIds(chatIds: List<Int>): Int
+
     fun findLatestChatsByMember(apiKey: String): List<Chat>
 
     fun countUnreadMessagesByRoomIds(roomIds: List<String>, memberId: Int): List<UnreadCountResponse>
 
+    fun countUnreadMessagesByRoomId(roomId: String, memberId: Int): Int
+
     fun findRecentChats(roomId: String, lastChatId: Int?): List<Chat>
 }
-

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,6 +1,10 @@
 initdata:
   enabled: true
 
+chat:
+  events:
+    async-enabled: false
+
 spring:
   datasource:
     url: jdbc:h2:mem:db_test;MODE=MySQL

--- a/src/test/java/com/back/domain/chat/chat/service/ChatServiceTest.kt
+++ b/src/test/java/com/back/domain/chat/chat/service/ChatServiceTest.kt
@@ -43,6 +43,7 @@ class ChatServiceTest {
         chatPublishPort,
         rq,
         eventPublisher,
+        false,
     )
 
     @Test

--- a/src/test/java/com/back/domain/chat/chat/service/ChatServiceTest.kt
+++ b/src/test/java/com/back/domain/chat/chat/service/ChatServiceTest.kt
@@ -10,6 +10,7 @@ import com.back.domain.chat.chat.service.port.ChatPublishPort
 import com.back.domain.member.member.entity.Member
 import com.back.global.exception.ServiceException
 import com.back.global.rq.Rq
+import org.springframework.context.ApplicationEventPublisher
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
@@ -32,6 +33,7 @@ class ChatServiceTest {
     private val chatMediaPort: ChatMediaPort = mock(ChatMediaPort::class.java)
     private val chatPublishPort: ChatPublishPort = mock(ChatPublishPort::class.java)
     private val rq: Rq = mock(Rq::class.java)
+    private val eventPublisher: ApplicationEventPublisher = mock(ApplicationEventPublisher::class.java)
 
     private val chatService = ChatService(
         chatPersistencePort,
@@ -39,7 +41,8 @@ class ChatServiceTest {
         chatMemberPort,
         chatMediaPort,
         chatPublishPort,
-        rq
+        rq,
+        eventPublisher,
     )
 
     @Test


### PR DESCRIPTION
## 🔗 Issue 번호
- close #252 

## 🛠 작업 내역
saveMessage 후속 처리 비동기화
=> 메시지 저장 후 즉시 브로드캐스트/개인알림을 보내던 흐름을 커밋 후 비동기 이벤트로 분리

이미지 업로드 구간 트랜잭션 체류 축소
=> saveChatImages를 Propagation.NOT_SUPPORTED로 분리해 외부 스토리지 I/O가 메인 트랜잭션 점유를 덜 하게 조정.

채팅 목록 최신 메시지 조회 쿼리 경량화
=> 기존 MAX(id)+GROUP BY로 엔티티를 바로 가져오던 구조를 “최신 ID 조회 -> 필요한 엔티티 재조회” 2단계로 변경.

메시지 조회 조인 폭 축소
=> 최근 메시지 조회에서 chatImages fetch join + DISTINCT 경로를 제거하고 ID 기반 단순 조회로 전환.

## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

