### PR TITLE
[Refactor] 채팅 도메인 성능 최적화

### DIFF
--- a/src/main/java/com/back/domain/chat/chat/controller/ChatController.kt
+++ b/src/main/java/com/back/domain/chat/chat/controller/ChatController.kt
@@ -5,7 +5,7 @@ import com.back.domain.chat.chat.dto.response.ChatIdResponse
 import com.back.domain.chat.chat.dto.response.ChatResponse
 import com.back.domain.chat.chat.dto.response.ChatRoomIdResponse
 import com.back.domain.chat.chat.dto.response.ChatRoomListResponse
-import com.back.domain.chat.chat.service.ChatService
+import com.back.domain.chat.chat.service.port.ChatUseCase
 import com.back.global.rsData.RsData
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/chat")
 class ChatController(
-    private val chatService: ChatService,
+    private val chatService: ChatUseCase,
 ) {
     @Operation(summary = "채팅방 생성 또는 입장", description = "거래 타입(POST/AUCTION)과 아이템 ID를 기준으로 채팅방을 생성하거나 기존 채팅방에 입장합니다.")
     @ApiResponses(

--- a/src/main/java/com/back/domain/chat/chat/repository/ChatRepository.kt
+++ b/src/main/java/com/back/domain/chat/chat/repository/ChatRepository.kt
@@ -9,6 +9,12 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
 interface ChatRepository : JpaRepository<Chat, Int> {
+    interface ChatRoomLatestSummaryProjection {
+        fun getRoomId(): String
+        fun getLatestChatId(): Int
+        fun getUnreadCount(): Long?
+    }
+
     // 읽음 처리 (JPQL) - 업데이트된 행 수 반환
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Chat c SET c.read = true WHERE c.chatRoom.roomId = :roomId AND c.senderId != :readerId AND c.read = false")
@@ -32,6 +38,29 @@ interface ChatRepository : JpaRepository<Chat, Int> {
                 "ORDER BY c.createDate DESC",
     )
     fun findLatestChatIdsByMember(@Param("apiKey") apiKey: String): List<Int>
+
+    @Query(
+        value = """
+            SELECT
+                cr.room_id AS roomId,
+                MAX(c.id) AS latestChatId,
+                SUM(CASE WHEN c.is_read = false AND c.sender_id <> :memberId THEN 1 ELSE 0 END) AS unreadCount
+            FROM chat_room cr
+            JOIN chat c ON c.room_id = cr.room_id
+            WHERE cr.deleted = false
+              AND (
+                    (cr.seller_api_key = :apiKey AND cr.seller_exited = false)
+                 OR (cr.buyer_api_key = :apiKey AND cr.buyer_exited = false)
+              )
+            GROUP BY cr.room_id
+            ORDER BY latestChatId DESC
+        """,
+        nativeQuery = true,
+    )
+    fun findLatestChatSummariesByMember(
+        @Param("apiKey") apiKey: String,
+        @Param("memberId") memberId: Int,
+    ): List<ChatRoomLatestSummaryProjection>
 
     // 테스트/기존 호출 호환용 (서비스 핵심 경로에서는 ID 조회 + 재조회 방식 사용)
     @Query(

--- a/src/main/java/com/back/domain/chat/chat/service/ChatService.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/ChatService.kt
@@ -18,6 +18,7 @@ import com.back.domain.chat.chat.service.port.ChatMediaPort
 import com.back.domain.chat.chat.service.port.ChatPersistencePort
 import com.back.domain.chat.chat.service.port.ChatPublishPort
 import com.back.domain.chat.chat.service.port.ChatUploadFile
+import com.back.domain.chat.chat.service.port.ChatUseCase
 import com.back.global.exception.ServiceException
 import com.back.global.rq.Rq
 import com.back.global.rsData.RsData
@@ -42,11 +43,11 @@ class ChatService(
     private val eventPublisher: ApplicationEventPublisher,
     @Value("\${chat.events.async-enabled:true}")
     private val asyncEventsEnabled: Boolean,
-) {
+) : ChatUseCase {
     private val memberCache = ConcurrentHashMap<Int, CachedCurrentMember>()
 
     @Transactional
-    fun createChatRoom(itemId: Int, txType: String): RsData<ChatRoomIdResponse> {
+    override fun createChatRoom(itemId: Int, txType: String): RsData<ChatRoomIdResponse> {
         val type = parseTxType(txType)
         val buyer = currentMemberFromDb()
 
@@ -108,7 +109,7 @@ class ChatService(
     }
 
     @Transactional
-    fun saveMessage(req: ChatMessageRequest): RsData<ChatIdResponse> {
+    override fun saveMessage(req: ChatMessageRequest): RsData<ChatIdResponse> {
         val roomId = req.roomId ?: throw ServiceException("400-1", "채팅방 ID는 필수입니다.")
         val room = findActiveRoom(roomId)
 
@@ -178,7 +179,7 @@ class ChatService(
     }
 
     @Transactional
-    fun getMessages(roomId: String, lastChatId: Int?): RsData<List<ChatResponse>> {
+    override fun getMessages(roomId: String, lastChatId: Int?): RsData<List<ChatResponse>> {
         val room = findActiveRoom(roomId)
 
         val me = currentMemberFromDb()
@@ -228,27 +229,26 @@ class ChatService(
         return RsData("200-1", "메시지 조회 성공", responses)
     }
 
-    fun getChatList(): RsData<List<ChatRoomListResponse>> {
+    override fun getChatList(): RsData<List<ChatRoomListResponse>> {
         val me = currentMemberFromDb()
         val myApiKey = me.apiKey
 
-        val latestChats = chatPersistencePort.findLatestChatsByMember(myApiKey)
+        val latestSummaries = chatPersistencePort.findLatestChatSummariesByMember(myApiKey, me.id)
+        if (latestSummaries.isEmpty()) {
+            return RsData("200-1", "채팅 목록 조회 성공", emptyList())
+        }
+
+        val latestChats = chatPersistencePort.findChatsWithRoomsByIds(latestSummaries.map { it.latestChatId })
         if (latestChats.isEmpty()) {
             return RsData("200-1", "채팅 목록 조회 성공", emptyList())
         }
 
-        val roomIds = latestChats.mapNotNull { it.chatRoom?.roomId }.distinct()
+        val unreadCountMap = latestSummaries.associate { it.roomId to it.unreadCount }
         val opponentApiKeys = latestChats.mapNotNull { chat ->
             val room = chat.chatRoom ?: return@mapNotNull null
             if (room.sellerApiKey == myApiKey) room.buyerApiKey else room.sellerApiKey
         }.toSet()
 
-        val unreadCountMap = if (roomIds.isEmpty()) {
-            emptyMap()
-        } else {
-            chatPersistencePort.countUnreadMessagesByRoomIds(roomIds, me.id)
-                .associate { it.roomId to (it.count?.toInt() ?: 0) }
-        }
         val opponentMap = chatMemberPort.findMembersByApiKeys(opponentApiKeys)
 
         val responseList = latestChats.mapNotNull { chat ->
@@ -278,7 +278,7 @@ class ChatService(
     }
 
     @Transactional
-    fun exitChatRoom(roomId: String): RsData<Void?> {
+    override fun exitChatRoom(roomId: String): RsData<Void?> {
         val room = findActiveRoom(roomId)
         val me = currentMemberFromDb()
 

--- a/src/main/java/com/back/domain/chat/chat/service/adapter/ChatPersistenceAdapter.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/adapter/ChatPersistenceAdapter.kt
@@ -41,6 +41,19 @@ class ChatPersistenceAdapter(
                 if (chatIds.isEmpty()) emptyList() else chatRepository.findChatsWithRoomByIds(chatIds)
             }
 
+    override fun findLatestChatSummariesByMember(apiKey: String, memberId: Int): List<ChatPersistencePort.ChatRoomLatestSummary> =
+        chatRepository.findLatestChatSummariesByMember(apiKey, memberId)
+            .map { summary ->
+                ChatPersistencePort.ChatRoomLatestSummary(
+                    roomId = summary.getRoomId(),
+                    latestChatId = summary.getLatestChatId(),
+                    unreadCount = (summary.getUnreadCount() ?: 0L).toInt(),
+                )
+            }
+
+    override fun findChatsWithRoomsByIds(chatIds: List<Int>): List<Chat> =
+        if (chatIds.isEmpty()) emptyList() else chatRepository.findChatsWithRoomByIds(chatIds)
+
     override fun countUnreadMessagesByRoomIds(roomIds: List<String>, memberId: Int): List<UnreadCountResponse> =
         chatRepository.countUnreadMessagesByRoomIds(roomIds, memberId)
 

--- a/src/main/java/com/back/domain/chat/chat/service/port/ChatPersistencePort.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/port/ChatPersistencePort.kt
@@ -10,6 +10,12 @@ import com.back.domain.chat.chat.entity.ChatRoomType
  * 서비스는 저장소 구현(JPA 등) 대신 이 포트에 의존한다.
  */
 interface ChatPersistencePort {
+    data class ChatRoomLatestSummary(
+        val roomId: String,
+        val latestChatId: Int,
+        val unreadCount: Int,
+    )
+
     fun findActiveRoom(roomId: String): ChatRoom?
 
     fun findExistingRoom(txType: ChatRoomType, itemId: Int, buyerApiKey: String): ChatRoom?
@@ -23,6 +29,10 @@ interface ChatPersistencePort {
     fun markMessagesAsReadByIds(chatIds: List<Int>): Int
 
     fun findLatestChatsByMember(apiKey: String): List<Chat>
+
+    fun findLatestChatSummariesByMember(apiKey: String, memberId: Int): List<ChatRoomLatestSummary>
+
+    fun findChatsWithRoomsByIds(chatIds: List<Int>): List<Chat>
 
     fun countUnreadMessagesByRoomIds(roomIds: List<String>, memberId: Int): List<UnreadCountResponse>
 

--- a/src/main/java/com/back/domain/chat/chat/service/port/ChatUseCase.kt
+++ b/src/main/java/com/back/domain/chat/chat/service/port/ChatUseCase.kt
@@ -1,0 +1,17 @@
+package com.back.domain.chat.chat.service.port
+
+import com.back.domain.chat.chat.dto.request.ChatMessageRequest
+import com.back.domain.chat.chat.dto.response.ChatIdResponse
+import com.back.domain.chat.chat.dto.response.ChatResponse
+import com.back.domain.chat.chat.dto.response.ChatRoomIdResponse
+import com.back.domain.chat.chat.dto.response.ChatRoomListResponse
+import com.back.global.rsData.RsData
+
+// Inbound port: 웹 어댑터가 의존해야 하는 채팅 유스케이스 계약.
+interface ChatUseCase {
+    fun createChatRoom(itemId: Int, txType: String): RsData<ChatRoomIdResponse>
+    fun saveMessage(req: ChatMessageRequest): RsData<ChatIdResponse>
+    fun getMessages(roomId: String, lastChatId: Int?): RsData<List<ChatResponse>>
+    fun getChatList(): RsData<List<ChatRoomListResponse>>
+    fun exitChatRoom(roomId: String): RsData<Void?>
+}


### PR DESCRIPTION
## 🔗 Issue 번호
- close #256 

## 🛠 작업 내역
chat/list 최신메시지+미읽음 집계 비용 최적화
- 방별 latestChatId + unreadCount를 한 번에 집계하는 native query 추가 후, 최신 chat만 재조회

## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

