### PR TITLE
[Refactor/#262] 경매 목록 Page 응답 유지 기반 조회 최적화

### DIFF
--- a/src/main/java/com/back/domain/auction/auction/repository/AuctionRepository.kt
+++ b/src/main/java/com/back/domain/auction/auction/repository/AuctionRepository.kt
@@ -26,13 +26,13 @@ interface AuctionRepository : JpaRepository<Auction, Int> {
     fun findBySellerIdAndStatus(sellerId: Int, status: AuctionStatus, pageable: Pageable): Page<Auction>
 
     @EntityGraph(attributePaths = ["seller", "seller.reputation", "category"])
-    fun findByCategoryName(categoryName: String, pageable: Pageable): Page<Auction>
+    fun findByCategoryId(categoryId: Int, pageable: Pageable): Page<Auction>
 
     @EntityGraph(attributePaths = ["seller", "seller.reputation", "category"])
     fun findByStatus(status: AuctionStatus, pageable: Pageable): Page<Auction>
 
     @EntityGraph(attributePaths = ["seller", "seller.reputation", "category"])
-    fun findByCategoryNameAndStatus(categoryName: String, status: AuctionStatus, pageable: Pageable): Page<Auction>
+    fun findByCategoryIdAndStatus(categoryId: Int, status: AuctionStatus, pageable: Pageable): Page<Auction>
 
     @EntityGraph(attributePaths = ["seller", "seller.reputation", "category", "auctionImages", "auctionImages.image"])
     fun findWithDetailsById(id: Int): Optional<Auction>

--- a/src/main/java/com/back/domain/auction/auction/service/AuctionService.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/AuctionService.kt
@@ -26,6 +26,7 @@ import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import org.springframework.data.domain.Page
 
 @Service
 @Transactional(readOnly = true)
@@ -103,12 +104,17 @@ class AuctionService(
     ): RsData<AuctionPageResponse> {
         val pageable = PageUtils.createPageable(page, size, createSort(sortBy))
         val auctionStatus = parseAuctionStatus(status)
+        val categoryId = categoryName?.takeIf { it.isNotBlank() }?.trim()
+            ?.let { normalizedName ->
+                categoryPort.findByNameOrNull(normalizedName)?.id
+                    ?: return RsData("200-1", "경매 목록 조회 성공", AuctionPageResponse.from(Page.empty(pageable)))
+            }
 
         val auctionPage = when {
-            !categoryName.isNullOrBlank() && auctionStatus != null ->
-                auctionPersistencePort.findByCategoryNameAndStatus(categoryName, auctionStatus, pageable)
-            !categoryName.isNullOrBlank() ->
-                auctionPersistencePort.findByCategoryName(categoryName, pageable)
+            categoryId != null && auctionStatus != null ->
+                auctionPersistencePort.findByCategoryIdAndStatus(categoryId, auctionStatus, pageable)
+            categoryId != null ->
+                auctionPersistencePort.findByCategoryId(categoryId, pageable)
             auctionStatus != null ->
                 auctionPersistencePort.findByStatus(auctionStatus, pageable)
             else ->

--- a/src/main/java/com/back/domain/auction/auction/service/adapter/AuctionPersistenceAdapter.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/adapter/AuctionPersistenceAdapter.kt
@@ -31,17 +31,17 @@ class AuctionPersistenceAdapter(
     override fun findBySellerIdAndStatus(sellerId: Int, status: AuctionStatus, pageable: Pageable): Page<Auction> =
         auctionRepository.findBySellerIdAndStatus(sellerId, status, pageable)
 
-    override fun findByCategoryName(categoryName: String, pageable: Pageable): Page<Auction> =
-        auctionRepository.findByCategoryName(categoryName, pageable)
+    override fun findByCategoryId(categoryId: Int, pageable: Pageable): Page<Auction> =
+        auctionRepository.findByCategoryId(categoryId, pageable)
 
     override fun findByStatus(status: AuctionStatus, pageable: Pageable): Page<Auction> =
         auctionRepository.findByStatus(status, pageable)
 
-    override fun findByCategoryNameAndStatus(
-        categoryName: String,
+    override fun findByCategoryIdAndStatus(
+        categoryId: Int,
         status: AuctionStatus,
         pageable: Pageable
-    ): Page<Auction> = auctionRepository.findByCategoryNameAndStatus(categoryName, status, pageable)
+    ): Page<Auction> = auctionRepository.findByCategoryIdAndStatus(categoryId, status, pageable)
 
     override fun findExpiredOpenAuctions(now: LocalDateTime): List<Auction> =
         auctionRepository.findByStatusAndEndAtBefore(AuctionStatus.OPEN, now)

--- a/src/main/java/com/back/domain/auction/auction/service/port/AuctionPersistencePort.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/port/AuctionPersistencePort.kt
@@ -15,8 +15,8 @@ interface AuctionPersistencePort {
     fun findAll(pageable: Pageable): Page<Auction>
     fun findBySellerId(sellerId: Int, pageable: Pageable): Page<Auction>
     fun findBySellerIdAndStatus(sellerId: Int, status: AuctionStatus, pageable: Pageable): Page<Auction>
-    fun findByCategoryName(categoryName: String, pageable: Pageable): Page<Auction>
+    fun findByCategoryId(categoryId: Int, pageable: Pageable): Page<Auction>
     fun findByStatus(status: AuctionStatus, pageable: Pageable): Page<Auction>
-    fun findByCategoryNameAndStatus(categoryName: String, status: AuctionStatus, pageable: Pageable): Page<Auction>
+    fun findByCategoryIdAndStatus(categoryId: Int, status: AuctionStatus, pageable: Pageable): Page<Auction>
     fun findExpiredOpenAuctions(now: LocalDateTime): List<Auction>
 }

--- a/src/main/java/com/back/domain/category/category/repository/CategoryRepository.kt
+++ b/src/main/java/com/back/domain/category/category/repository/CategoryRepository.kt
@@ -4,3 +4,6 @@ import com.back.domain.category.category.entity.Category
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface CategoryRepository : JpaRepository<Category, Int>
+{
+    fun findByName(name: String): Category?
+}

--- a/src/main/java/com/back/domain/category/category/service/adapter/CategoryAdapter.kt
+++ b/src/main/java/com/back/domain/category/category/service/adapter/CategoryAdapter.kt
@@ -17,6 +17,8 @@ class CategoryAdapter(
         categoryRepository.findByIdOrNull(categoryId)
             ?: throw ServiceException("404-2", "존재하지 않는 카테고리입니다.")
 
+    override fun findByNameOrNull(name: String): Category? = categoryRepository.findByName(name)
+
     override fun count(): Long = categoryRepository.count()
 
     override fun save(category: Category): Category = categoryRepository.save(category)

--- a/src/main/java/com/back/domain/category/category/service/port/CategoryPort.kt
+++ b/src/main/java/com/back/domain/category/category/service/port/CategoryPort.kt
@@ -6,6 +6,7 @@ import com.back.domain.category.category.entity.Category
 // 다른 도메인은 이 인터페이스에만 의존하고, 구현(Repository/JPA)은 어댑터로 숨긴다.
 interface CategoryPort {
     fun getByIdOrThrow(categoryId: Int): Category
+    fun findByNameOrNull(name: String): Category?
     fun count(): Long
     fun save(category: Category): Category
     fun findAll(): List<Category>

--- a/src/test/java/com/back/domain/auction/auction/service/AuctionServiceTest.kt
+++ b/src/test/java/com/back/domain/auction/auction/service/AuctionServiceTest.kt
@@ -100,6 +100,19 @@ class AuctionServiceTest {
     }
 
     @Test
+    @DisplayName("존재하지 않는 카테고리 이름으로 목록 조회하면 빈 페이지를 반환한다.")
+    fun t3_1() {
+        `when`(categoryPort.findByNameOrNull("없는카테고리")).thenReturn(null)
+
+        val result = auctionService.getAuctions(0, 20, null, "없는카테고리", null)
+
+        assertThat(result.resultCode).isEqualTo("200-1")
+        assertThat(result.data!!.content).isEmpty()
+        assertThat(result.data!!.totalElements).isZero()
+        assertThat(result.data!!.totalPages).isZero()
+    }
+
+    @Test
     @DisplayName("유저별 경매 목록은 상태 필터 없이 조회 가능하다.")
     fun t4() {
         val seller = member(1, "seller")


### PR DESCRIPTION
## 🔗 Issue 번호
- close #262

## 🛠 작업 내역
- 경매 목록 조회에서 카테고리 필터를 `categoryName` 직접 조건에서 `category_id` 기반 조건으로 변경
- 카테고리 이름은 선조회(1회)로 ID 변환 후 목록/카운트 쿼리에 적용
- 미존재 카테고리 이름 요청 시 DB 목록 조회를 수행하지 않고 빈 Page 응답 반환
- 관련 포트/어댑터/리포지토리 시그니처 정합성 반영
- 서비스 테스트 추가

## 🔄 변경 사항
- `AuctionRepository`
  - `findByCategoryName*` -> `findByCategoryId*`
- `AuctionPersistencePort`, `AuctionPersistenceAdapter`
  - 카테고리 기반 조회 메서드 시그니처를 ID 기준으로 변경
- `CategoryRepository`, `CategoryPort`, `CategoryAdapter`
  - `findByNameOrNull` 경로 추가
- `AuctionService.getAuctions`
  - 카테고리 이름 -> ID 변환 후 ID 기반 조회
  - 카테고리 미존재 시 빈 `AuctionPageResponse` 즉시 반환
- `AuctionServiceTest`
  - 미존재 카테고리 빈 응답 테스트 추가

## ✨ 새로운 기능
- 없음 (응답 스펙 유지 조건에서 조회 성능 최적화)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?