### PR TITLE
[Refactor/#264] 경매 목록 total count 캐시 도입

### DIFF
--- a/src/main/java/com/back/domain/auction/auction/dto/response/AuctionPageResponse.kt
+++ b/src/main/java/com/back/domain/auction/auction/dto/response/AuctionPageResponse.kt
@@ -19,5 +19,22 @@ data class AuctionPageResponse(
                 totalElements = page.totalElements,
                 totalPages = page.totalPages
             )
+
+        @JvmStatic
+        fun of(
+            content: List<AuctionListItemDto>,
+            page: Int,
+            size: Int,
+            totalElements: Long
+        ): AuctionPageResponse {
+            val totalPages = if (totalElements == 0L) 0 else ((totalElements + size - 1) / size).toInt()
+            return AuctionPageResponse(
+                content = content,
+                page = page,
+                size = size,
+                totalElements = totalElements,
+                totalPages = totalPages
+            )
+        }
     }
 }

--- a/src/main/java/com/back/domain/auction/auction/repository/AuctionRepository.kt
+++ b/src/main/java/com/back/domain/auction/auction/repository/AuctionRepository.kt
@@ -5,6 +5,7 @@ import com.back.domain.auction.auction.entity.AuctionStatus
 import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
@@ -34,6 +35,18 @@ interface AuctionRepository : JpaRepository<Auction, Int> {
     @EntityGraph(attributePaths = ["seller", "seller.reputation", "category"])
     fun findByCategoryIdAndStatus(categoryId: Int, status: AuctionStatus, pageable: Pageable): Page<Auction>
 
+    @EntityGraph(attributePaths = ["seller", "seller.reputation", "category"])
+    fun findSliceBy(pageable: Pageable): Slice<Auction>
+
+    @EntityGraph(attributePaths = ["seller", "seller.reputation", "category"])
+    fun findSliceByCategoryId(categoryId: Int, pageable: Pageable): Slice<Auction>
+
+    @EntityGraph(attributePaths = ["seller", "seller.reputation", "category"])
+    fun findSliceByStatus(status: AuctionStatus, pageable: Pageable): Slice<Auction>
+
+    @EntityGraph(attributePaths = ["seller", "seller.reputation", "category"])
+    fun findSliceByCategoryIdAndStatus(categoryId: Int, status: AuctionStatus, pageable: Pageable): Slice<Auction>
+
     @EntityGraph(attributePaths = ["seller", "seller.reputation", "category", "auctionImages", "auctionImages.image"])
     fun findWithDetailsById(id: Int): Optional<Auction>
 
@@ -49,6 +62,9 @@ interface AuctionRepository : JpaRepository<Auction, Int> {
     fun findByIdWithLock(@Param("id") id: Int): Optional<Auction>
 
     fun countByNameStartingWith(prefix: String): Long
+    fun countByStatus(status: AuctionStatus): Long
+    fun countByCategoryId(categoryId: Int): Long
+    fun countByCategoryIdAndStatus(categoryId: Int, status: AuctionStatus): Long
 
     fun deleteByNameStartingWith(prefix: String): Long
 

--- a/src/main/java/com/back/domain/auction/auction/service/AuctionCountService.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/AuctionCountService.kt
@@ -1,0 +1,26 @@
+package com.back.domain.auction.auction.service
+
+import com.back.domain.auction.auction.entity.AuctionStatus
+import com.back.domain.auction.auction.service.port.AuctionPersistencePort
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AuctionCountService(
+    private val auctionPersistencePort: AuctionPersistencePort
+) {
+    @Cacheable(value = ["auctionCount"], key = "#cacheKey")
+    fun getTotalCount(cacheKey: String, categoryId: Int?, status: AuctionStatus?): Long =
+        when {
+            categoryId != null && status != null -> auctionPersistencePort.countByCategoryIdAndStatus(categoryId, status)
+            categoryId != null -> auctionPersistencePort.countByCategoryId(categoryId)
+            status != null -> auctionPersistencePort.countByStatus(status)
+            else -> auctionPersistencePort.countAll()
+        }
+
+    @CacheEvict(value = ["auctionCount"], allEntries = true)
+    fun evictAll() = Unit
+}

--- a/src/main/java/com/back/domain/auction/auction/service/AuctionService.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/AuctionService.kt
@@ -32,6 +32,7 @@ import org.springframework.data.domain.Page
 @Transactional(readOnly = true)
 class AuctionService(
     private val auctionPersistencePort: AuctionPersistencePort,
+    private val auctionCountService: AuctionCountService,
     private val categoryPort: CategoryPort,
     private val auctionMemberPort: AuctionMemberPort,
     private val auctionImagePort: AuctionImagePort
@@ -84,6 +85,7 @@ class AuctionService(
         )
 
         val responseData = AuctionIdResponse(savedAuction.id, "경매 물품이 등록되었습니다.")
+        auctionCountService.evictAll()
         return RsData("201-1", "경매 물품이 등록되었습니다.", responseData)
     }
 
@@ -107,23 +109,25 @@ class AuctionService(
         val categoryId = categoryName?.takeIf { it.isNotBlank() }?.trim()
             ?.let { normalizedName ->
                 categoryPort.findByNameOrNull(normalizedName)?.id
-                    ?: return RsData("200-1", "경매 목록 조회 성공", AuctionPageResponse.from(Page.empty(pageable)))
+                    ?: return RsData("200-1", "경매 목록 조회 성공", AuctionPageResponse.of(emptyList(), page, size, 0))
             }
 
-        val auctionPage = when {
+        val auctionSlice = when {
             categoryId != null && auctionStatus != null ->
-                auctionPersistencePort.findByCategoryIdAndStatus(categoryId, auctionStatus, pageable)
+                auctionPersistencePort.findSliceByCategoryIdAndStatus(categoryId, auctionStatus, pageable)
             categoryId != null ->
-                auctionPersistencePort.findByCategoryId(categoryId, pageable)
+                auctionPersistencePort.findSliceByCategoryId(categoryId, pageable)
             auctionStatus != null ->
-                auctionPersistencePort.findByStatus(auctionStatus, pageable)
+                auctionPersistencePort.findSliceByStatus(auctionStatus, pageable)
             else ->
-                auctionPersistencePort.findAll(pageable)
+                auctionPersistencePort.findSliceAll(pageable)
         }
 
-        val dtoPage = auctionPage.map { auction -> AuctionListItemDto(auction) }
+        val content = auctionSlice.content.map { auction -> AuctionListItemDto(auction) }
+        val countCacheKey = buildCountCacheKey(categoryId, auctionStatus)
+        val totalElements = auctionCountService.getTotalCount(countCacheKey, categoryId, auctionStatus)
 
-        return RsData("200-1", "경매 목록 조회 성공", AuctionPageResponse.from(dtoPage))
+        return RsData("200-1", "경매 목록 조회 성공", AuctionPageResponse.of(content, page, size, totalElements))
     }
 
     override fun getAuctionsByUserId(
@@ -170,6 +174,9 @@ class AuctionService(
         return Sort.by(direction, property)
     }
 
+    private fun buildCountCacheKey(categoryId: Int?, status: AuctionStatus?): String =
+        "category:${categoryId ?: "ALL"}:status:${status?.name ?: "ALL"}"
+
     @Cacheable(value = ["auction"], key = "#auctionId")
     override fun getAuctionDetailData(auctionId: Int): AuctionDetailResponse {
         log.debug("[Cache Miss] DB에서 경매 조회 - auctionId: {}", auctionId)
@@ -209,6 +216,7 @@ class AuctionService(
         }
 
         auctionPersistencePort.save(auction)
+        auctionCountService.evictAll()
         val response = AuctionUpdateResponse(auction.id, "경매 물품이 수정되었습니다.")
         return RsData("200-1", "경매 물품이 수정되었습니다.", response)
     }
@@ -247,6 +255,7 @@ class AuctionService(
 
         auctionMemberPort.applyCancelPenalty(auctionId, memberId)
         auctionPersistencePort.delete(auction)
+        auctionCountService.evictAll()
 
         log.info("경매 삭제 완료 - 경매 ID: {}, 판매자 ID: {}, 입찰 수: {}", auctionId, memberId, auction.bidCount)
         val response = AuctionDeleteResponse("경매가 정상적으로 취소되었습니다.")
@@ -273,6 +282,7 @@ class AuctionService(
 
         auction.cancelTrade(memberId, role)
         auctionPersistencePort.save(auction)
+        auctionCountService.evictAll()
 
         log.info("거래 취소 완료 - 경매 ID: {}, 취소자 역할: {}, 취소자 ID: {}", auctionId, role, memberId)
         return RsData("200-1", "거래가 취소되었습니다.", null)

--- a/src/main/java/com/back/domain/auction/auction/service/adapter/AuctionPersistenceAdapter.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/adapter/AuctionPersistenceAdapter.kt
@@ -6,6 +6,7 @@ import com.back.domain.auction.auction.repository.AuctionRepository
 import com.back.domain.auction.auction.service.port.AuctionPersistencePort
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
@@ -42,6 +43,27 @@ class AuctionPersistenceAdapter(
         status: AuctionStatus,
         pageable: Pageable
     ): Page<Auction> = auctionRepository.findByCategoryIdAndStatus(categoryId, status, pageable)
+
+    override fun findSliceAll(pageable: Pageable): Slice<Auction> =
+        auctionRepository.findSliceBy(pageable)
+
+    override fun findSliceByCategoryId(categoryId: Int, pageable: Pageable): Slice<Auction> =
+        auctionRepository.findSliceByCategoryId(categoryId, pageable)
+
+    override fun findSliceByStatus(status: AuctionStatus, pageable: Pageable): Slice<Auction> =
+        auctionRepository.findSliceByStatus(status, pageable)
+
+    override fun findSliceByCategoryIdAndStatus(categoryId: Int, status: AuctionStatus, pageable: Pageable): Slice<Auction> =
+        auctionRepository.findSliceByCategoryIdAndStatus(categoryId, status, pageable)
+
+    override fun countAll(): Long = auctionRepository.count()
+
+    override fun countByStatus(status: AuctionStatus): Long = auctionRepository.countByStatus(status)
+
+    override fun countByCategoryId(categoryId: Int): Long = auctionRepository.countByCategoryId(categoryId)
+
+    override fun countByCategoryIdAndStatus(categoryId: Int, status: AuctionStatus): Long =
+        auctionRepository.countByCategoryIdAndStatus(categoryId, status)
 
     override fun findExpiredOpenAuctions(now: LocalDateTime): List<Auction> =
         auctionRepository.findByStatusAndEndAtBefore(AuctionStatus.OPEN, now)

--- a/src/main/java/com/back/domain/auction/auction/service/port/AuctionPersistencePort.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/port/AuctionPersistencePort.kt
@@ -4,6 +4,7 @@ import com.back.domain.auction.auction.entity.Auction
 import com.back.domain.auction.auction.entity.AuctionStatus
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import java.time.LocalDateTime
 
 // Outbound port: 경매 영속화 접근을 애플리케이션 계층에서 추상화한다.
@@ -18,5 +19,13 @@ interface AuctionPersistencePort {
     fun findByCategoryId(categoryId: Int, pageable: Pageable): Page<Auction>
     fun findByStatus(status: AuctionStatus, pageable: Pageable): Page<Auction>
     fun findByCategoryIdAndStatus(categoryId: Int, status: AuctionStatus, pageable: Pageable): Page<Auction>
+    fun findSliceAll(pageable: Pageable): Slice<Auction>
+    fun findSliceByCategoryId(categoryId: Int, pageable: Pageable): Slice<Auction>
+    fun findSliceByStatus(status: AuctionStatus, pageable: Pageable): Slice<Auction>
+    fun findSliceByCategoryIdAndStatus(categoryId: Int, status: AuctionStatus, pageable: Pageable): Slice<Auction>
+    fun countAll(): Long
+    fun countByStatus(status: AuctionStatus): Long
+    fun countByCategoryId(categoryId: Int): Long
+    fun countByCategoryIdAndStatus(categoryId: Int, status: AuctionStatus): Long
     fun findExpiredOpenAuctions(now: LocalDateTime): List<Auction>
 }

--- a/src/main/java/com/back/global/config/CacheConfig.kt
+++ b/src/main/java/com/back/global/config/CacheConfig.kt
@@ -3,7 +3,8 @@ package com.back.global.config
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
-import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.cache.caffeine.CaffeineCache
+import org.springframework.cache.support.SimpleCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.util.concurrent.TimeUnit
@@ -13,12 +14,26 @@ import java.util.concurrent.TimeUnit
 class CacheConfig {
     @Bean
     fun cacheManager(): CacheManager {
-        val cacheManager = CaffeineCacheManager("auction")
-        cacheManager.setCaffeine(
-            Caffeine.newBuilder()
-                .maximumSize(500)
-                .expireAfterWrite(10, TimeUnit.MINUTES)
-                .recordStats(),
+        val cacheManager = SimpleCacheManager()
+        cacheManager.setCaches(
+            listOf(
+                CaffeineCache(
+                    "auction",
+                    Caffeine.newBuilder()
+                        .maximumSize(500)
+                        .expireAfterWrite(10, TimeUnit.MINUTES)
+                        .recordStats()
+                        .build()
+                ),
+                CaffeineCache(
+                    "auctionCount",
+                    Caffeine.newBuilder()
+                        .maximumSize(1_000)
+                        .expireAfterWrite(10, TimeUnit.SECONDS)
+                        .recordStats()
+                        .build()
+                )
+            ),
         )
         return cacheManager
     }

--- a/src/test/java/com/back/domain/auction/auction/service/AuctionServiceTest.kt
+++ b/src/test/java/com/back/domain/auction/auction/service/AuctionServiceTest.kt
@@ -37,11 +37,13 @@ class AuctionServiceTest {
         }
     }
     private val categoryPort: CategoryPort = mock(CategoryPort::class.java)
+    private val auctionCountService: AuctionCountService = mock(AuctionCountService::class.java)
     private val auctionMemberPort: AuctionMemberPort = mock(AuctionMemberPort::class.java)
     private val auctionImagePort: AuctionImagePort = mock(AuctionImagePort::class.java)
 
     private val auctionService = AuctionService(
         auctionPersistencePort,
+        auctionCountService,
         categoryPort,
         auctionMemberPort,
         auctionImagePort


### PR DESCRIPTION
## 🔗 Issue 번호
- close #264

## 🛠 작업 내역
- 경매 목록 응답(`AuctionPageResponse`)은 유지하면서 count 쿼리 부하를 줄이기 위해 count 캐시를 도입
- 목록 본문 조회는 `Slice` 경로를 사용하고, total count는 캐시된 count 값을 사용하도록 분리
- 변경 작업(생성/수정/삭제/취소) 시 count 캐시 전체 무효화
- 캐시 설정을 분리해 `auctionCount` 캐시에 짧은 TTL 적용

## 🔄 변경 사항
- `CacheConfig`
  - `auction`(10분) + `auctionCount`(10초) 캐시 분리 구성
- `AuctionCountService` 신규 추가
  - 필터(category/status) 기준 total count 캐시 조회
  - 캐시 무효화 메서드 제공
- `AuctionRepository`/`AuctionPersistencePort`/`AuctionPersistenceAdapter`
  - 목록 본문용 Slice 조회 메서드 추가
  - count 전용 메서드 추가
- `AuctionService.getAuctions`
  - 본문은 Slice 조회
  - totalElements/totalPages는 count 캐시 기반 계산
  - 카테고리 미존재 시 빈 응답 즉시 반환
- `AuctionService`의 생성/수정/삭제/취소 로직에 count 캐시 무효화 추가
- `AuctionPageResponse`에 `of(...)` 팩토리 추가
- `AuctionServiceTest` 생성자 의존성 갱신

## ✨ 새로운 기능
- 없음 (성능 개선 목적 리팩터링)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?