### PR TITLE
[Refactor/#267] 경매 목록 응답 캐시 적용

### DIFF
--- a/src/main/java/com/back/domain/auction/auction/service/AuctionService.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/AuctionService.kt
@@ -21,6 +21,7 @@ import com.back.global.util.PageUtils
 import com.back.domain.category.category.service.port.CategoryPort
 import org.slf4j.LoggerFactory
 import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Caching
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
@@ -40,6 +41,7 @@ class AuctionService(
     private val log = LoggerFactory.getLogger(javaClass)
 
     @Transactional
+    @CacheEvict(value = ["auctionList"], allEntries = true)
     override fun createAuction(request: AuctionCreateRequest, sellerId: Int): RsData<AuctionIdResponse> {
         log.debug("경매 생성 시작 - 판매자 ID: {}, 물품명: {}, 시작가: {}원", sellerId, request.name, request.startPrice)
 
@@ -97,6 +99,7 @@ class AuctionService(
         }
     }
 
+    @Cacheable(value = ["auctionList"])
     override fun getAuctions(
         page: Int,
         size: Int,
@@ -186,7 +189,12 @@ class AuctionService(
     }
 
     @Transactional
-    @CacheEvict(value = ["auction"], key = "#auctionId")
+    @Caching(
+        evict = [
+            CacheEvict(value = ["auction"], key = "#auctionId"),
+            CacheEvict(value = ["auctionList"], allEntries = true),
+        ]
+    )
     override fun updateAuction(auctionId: Int, request: AuctionUpdateRequest, memberId: Int): RsData<AuctionUpdateResponse> {
         log.debug("경매 수정 시작 - 캐시 삭제: auctionId: {}", auctionId)
 
@@ -241,7 +249,12 @@ class AuctionService(
     }
 
     @Transactional
-    @CacheEvict(value = ["auction"], key = "#auctionId")
+    @Caching(
+        evict = [
+            CacheEvict(value = ["auction"], key = "#auctionId"),
+            CacheEvict(value = ["auctionList"], allEntries = true),
+        ]
+    )
     override fun deleteAuction(auctionId: Int, memberId: Int): RsData<AuctionDeleteResponse> {
         log.debug("경매 삭제 시작 - 캐시 삭제: auctionId: {}, 요청자 ID: {}", auctionId, memberId)
 
@@ -263,6 +276,12 @@ class AuctionService(
     }
 
     @Transactional
+    @Caching(
+        evict = [
+            CacheEvict(value = ["auction"], key = "#auctionId"),
+            CacheEvict(value = ["auctionList"], allEntries = true),
+        ]
+    )
     override fun cancelTrade(auctionId: Int, memberId: Int): RsData<Void> {
         log.debug("거래 취소 시작 - 경매 ID: {}, 요청자 ID: {}", auctionId, memberId)
 

--- a/src/main/java/com/back/global/config/CacheConfig.kt
+++ b/src/main/java/com/back/global/config/CacheConfig.kt
@@ -32,6 +32,14 @@ class CacheConfig {
                         .expireAfterWrite(10, TimeUnit.SECONDS)
                         .recordStats()
                         .build()
+                ),
+                CaffeineCache(
+                    "auctionList",
+                    Caffeine.newBuilder()
+                        .maximumSize(1_000)
+                        .expireAfterWrite(3, TimeUnit.SECONDS)
+                        .recordStats()
+                        .build()
                 )
             ),
         )


### PR DESCRIPTION
## 🔗 Issue 번호
- close #267

## 🛠 작업 내역
- 경매 목록 조회 응답(`getAuctions`)에 짧은 TTL 캐시 적용
- 경매 변경 작업(생성/수정/삭제/취소) 시 목록 캐시 무효화 추가
- 캐시 설정에 `auctionList` 캐시(3초 TTL) 추가

## 🔄 변경 사항
- `CacheConfig`
  - `auctionList` 캐시 신규 추가
  - `maximumSize=1000`, `expireAfterWrite=3s`
- `AuctionService`
  - `getAuctions`에 `@Cacheable("auctionList")` 적용
  - `createAuction`, `updateAuction`, `deleteAuction`, `cancelTrade`에 목록 캐시 무효화 적용

## ✨ 새로운 기능
- 없음 (성능 개선 목적 리팩터링)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?