### PR TITLE
[Refactor/#270] 경매 목록 캐시 TTL 10초로 조정

### DIFF
--- a/src/main/java/com/back/global/config/CacheConfig.kt
+++ b/src/main/java/com/back/global/config/CacheConfig.kt
@@ -37,7 +37,7 @@ class CacheConfig {
                     "auctionList",
                     Caffeine.newBuilder()
                         .maximumSize(1_000)
-                        .expireAfterWrite(3, TimeUnit.SECONDS)
+                        .expireAfterWrite(10, TimeUnit.SECONDS)
                         .recordStats()
                         .build()
                 )


### PR DESCRIPTION
## 🔗 Issue 번호
- close #270

## 🛠 작업 내역
- 경매 목록 응답 캐시(`auctionList`) TTL을 3초에서 10초로 조정

## 🔄 변경 사항
- `CacheConfig`의 `auctionList` 캐시 설정 변경
  - `expireAfterWrite(3, TimeUnit.SECONDS)` -> `expireAfterWrite(10, TimeUnit.SECONDS)`

## ✨ 새로운 기능
- 없음 (성능 개선 목적 설정 조정)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?