### PR TITLE
[Refactor/#273] 경매 목록 캐시 동시성 제어 및 키 정규화 적용

### DIFF
--- a/src/main/java/com/back/domain/auction/auction/service/AuctionCountService.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/AuctionCountService.kt
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional
 class AuctionCountService(
     private val auctionPersistencePort: AuctionPersistencePort
 ) {
-    @Cacheable(value = ["auctionCount"], key = "#cacheKey")
+    @Cacheable(value = ["auctionCount"], key = "#cacheKey", sync = true)
     fun getTotalCount(cacheKey: String, categoryId: Int?, status: AuctionStatus?): Long =
         when {
             categoryId != null && status != null -> auctionPersistencePort.countByCategoryIdAndStatus(categoryId, status)

--- a/src/main/java/com/back/domain/auction/auction/service/AuctionService.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/AuctionService.kt
@@ -99,7 +99,12 @@ class AuctionService(
         }
     }
 
-    @Cacheable(value = ["auctionList"])
+    @Cacheable(
+        value = ["auctionList"],
+        key = "#root.target.buildAuctionListCacheKey(#page, #size, #sortBy, #categoryName, #status)",
+        condition = "#page >= 0 && #page <= 9",
+        sync = true
+    )
     override fun getAuctions(
         page: Int,
         size: Int,
@@ -165,7 +170,12 @@ class AuctionService(
             }
 
     private fun createSort(sortBy: String?): Sort {
-        if (sortBy.isNullOrBlank()) return Sort.by(Sort.Direction.DESC, "createDate")
+        if (sortBy.isNullOrBlank()) {
+            return Sort.by(
+                Sort.Order.desc("createDate"),
+                Sort.Order.desc("id")
+            )
+        }
 
         val sortParams = sortBy.split(",")
         val property = sortParams[0]
@@ -174,11 +184,28 @@ class AuctionService(
         } else {
             Sort.Direction.DESC
         }
-        return Sort.by(direction, property)
+        return if (property == "createDate") {
+            Sort.by(Sort.Order(direction, "createDate"), Sort.Order(direction, "id"))
+        } else {
+            Sort.by(direction, property)
+        }
     }
 
     private fun buildCountCacheKey(categoryId: Int?, status: AuctionStatus?): String =
         "category:${categoryId ?: "ALL"}:status:${status?.name ?: "ALL"}"
+
+    fun buildAuctionListCacheKey(
+        page: Int,
+        size: Int,
+        sortBy: String?,
+        categoryName: String?,
+        status: String?
+    ): String {
+        val normalizedSort = sortBy?.trim()?.takeIf { it.isNotEmpty() }?.lowercase() ?: "createDate,desc"
+        val normalizedCategory = categoryName?.trim()?.takeIf { it.isNotEmpty() }?.lowercase() ?: "ALL"
+        val normalizedStatus = status?.trim()?.takeIf { it.isNotEmpty() }?.uppercase() ?: "ALL"
+        return "page:$page:size:$size:sort:$normalizedSort:category:$normalizedCategory:status:$normalizedStatus"
+    }
 
     @Cacheable(value = ["auction"], key = "#auctionId")
     override fun getAuctionDetailData(auctionId: Int): AuctionDetailResponse {

--- a/src/main/java/com/back/global/config/CacheConfig.kt
+++ b/src/main/java/com/back/global/config/CacheConfig.kt
@@ -37,7 +37,7 @@ class CacheConfig {
                     "auctionList",
                     Caffeine.newBuilder()
                         .maximumSize(1_000)
-                        .expireAfterWrite(10, TimeUnit.SECONDS)
+                        .expireAfterWrite(30, TimeUnit.SECONDS)
                         .recordStats()
                         .build()
                 )


### PR DESCRIPTION
## 🔗 Issue 번호
- close #273

## 🛠 작업 내역
- 경매 목록 캐시에 `sync=true` 적용
- 경매 목록 캐시 키를 명시적으로 구성하고 파라미터 정규화(lower/upper/trim) 적용
- 초기 조회 구간(`page <= 9`)만 목록 캐시에 저장하도록 조건 적용
- count 캐시에 `sync=true` 적용하여 캐시 미스 시 동시성 폭주 완화
- 기본 정렬을 `createDate desc, id desc`로 보강하여 정렬 안정성/인덱스 활용 정합성 개선
- `auctionList` TTL을 30초로 상향

## 🔄 변경 사항
- `AuctionService.getAuctions`의 캐시 정책(키/조건/동시성) 보강
- `AuctionCountService.getTotalCount` 캐시 동시성 제어 추가
- `CacheConfig`의 `auctionList` 만료시간 조정(10초 → 30초)

## ✨ 새로운 기능
- 없음 (기능 변경 없이 성능/안정성 리팩터링)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?