### PR TITLE
[Refactor/#275] 경매 목록 조회 DTO 프로젝션 쿼리 최적화

### DIFF
--- a/src/main/java/com/back/domain/auction/auction/dto/response/AuctionListProjection.kt
+++ b/src/main/java/com/back/domain/auction/auction/dto/response/AuctionListProjection.kt
@@ -1,0 +1,38 @@
+package com.back.domain.auction.auction.dto.response
+
+import com.back.domain.auction.auction.entity.AuctionStatus
+import java.time.LocalDateTime
+
+data class AuctionListProjection(
+    val auctionId: Int,
+    val name: String,
+    val startPrice: Int?,
+    val currentHighestBid: Int?,
+    val buyNowPrice: Int?,
+    val status: AuctionStatus,
+    val endAt: LocalDateTime,
+    val bidCount: Int,
+    val sellerId: Int,
+    val sellerNickname: String,
+    val sellerReputationScore: Double?,
+    val categoryName: String,
+    val thumbnailUrl: String?
+) {
+    fun toDto(): AuctionListItemDto = AuctionListItemDto(
+        auctionId = auctionId,
+        name = name,
+        startPrice = startPrice,
+        currentHighestBid = currentHighestBid,
+        buyNowPrice = buyNowPrice,
+        status = status,
+        endAt = endAt,
+        bidCount = bidCount,
+        seller = SellerDto(
+            id = sellerId,
+            nickname = sellerNickname,
+            reputationScore = sellerReputationScore
+        ),
+        categoryName = categoryName,
+        thumbnailUrl = thumbnailUrl
+    )
+}

--- a/src/main/java/com/back/domain/auction/auction/repository/AuctionRepository.kt
+++ b/src/main/java/com/back/domain/auction/auction/repository/AuctionRepository.kt
@@ -66,17 +66,17 @@ interface AuctionRepository : JpaRepository<Auction, Int> {
         """
         SELECT new com.back.domain.auction.auction.dto.response.AuctionListProjection(
             a.id, a.name, a.startPrice, a.currentHighestBid, a.buyNowPrice, a.status, a.endAt, a.bidCount,
-            s.id, s.nickname, r.score, c.name, a.thumbnailUrl
+            s.id, s.nickname, r.score, :categoryName, a.thumbnailUrl
         )
         FROM Auction a
         JOIN a.seller s
         LEFT JOIN s.reputation r
-        JOIN a.category c
-        WHERE c.id = :categoryId
+        WHERE a.category.id = :categoryId
         """
     )
     fun findSliceProjectionByCategoryId(
         @Param("categoryId") categoryId: Int,
+        @Param("categoryName") categoryName: String,
         pageable: Pageable
     ): Slice<AuctionListProjection>
 
@@ -102,18 +102,18 @@ interface AuctionRepository : JpaRepository<Auction, Int> {
         """
         SELECT new com.back.domain.auction.auction.dto.response.AuctionListProjection(
             a.id, a.name, a.startPrice, a.currentHighestBid, a.buyNowPrice, a.status, a.endAt, a.bidCount,
-            s.id, s.nickname, r.score, c.name, a.thumbnailUrl
+            s.id, s.nickname, r.score, :categoryName, a.thumbnailUrl
         )
         FROM Auction a
         JOIN a.seller s
         LEFT JOIN s.reputation r
-        JOIN a.category c
-        WHERE c.id = :categoryId AND a.status = :status
+        WHERE a.category.id = :categoryId AND a.status = :status
         """
     )
     fun findSliceProjectionByCategoryIdAndStatus(
         @Param("categoryId") categoryId: Int,
         @Param("status") status: AuctionStatus,
+        @Param("categoryName") categoryName: String,
         pageable: Pageable
     ): Slice<AuctionListProjection>
 

--- a/src/main/java/com/back/domain/auction/auction/repository/AuctionRepository.kt
+++ b/src/main/java/com/back/domain/auction/auction/repository/AuctionRepository.kt
@@ -1,5 +1,6 @@
 package com.back.domain.auction.auction.repository
 
+import com.back.domain.auction.auction.dto.response.AuctionListProjection
 import com.back.domain.auction.auction.entity.Auction
 import com.back.domain.auction.auction.entity.AuctionStatus
 import jakarta.persistence.LockModeType
@@ -46,6 +47,75 @@ interface AuctionRepository : JpaRepository<Auction, Int> {
 
     @EntityGraph(attributePaths = ["seller", "seller.reputation", "category"])
     fun findSliceByCategoryIdAndStatus(categoryId: Int, status: AuctionStatus, pageable: Pageable): Slice<Auction>
+
+    @Query(
+        """
+        SELECT new com.back.domain.auction.auction.dto.response.AuctionListProjection(
+            a.id, a.name, a.startPrice, a.currentHighestBid, a.buyNowPrice, a.status, a.endAt, a.bidCount,
+            s.id, s.nickname, r.score, c.name, a.thumbnailUrl
+        )
+        FROM Auction a
+        JOIN a.seller s
+        LEFT JOIN s.reputation r
+        JOIN a.category c
+        """
+    )
+    fun findSliceProjectionBy(pageable: Pageable): Slice<AuctionListProjection>
+
+    @Query(
+        """
+        SELECT new com.back.domain.auction.auction.dto.response.AuctionListProjection(
+            a.id, a.name, a.startPrice, a.currentHighestBid, a.buyNowPrice, a.status, a.endAt, a.bidCount,
+            s.id, s.nickname, r.score, c.name, a.thumbnailUrl
+        )
+        FROM Auction a
+        JOIN a.seller s
+        LEFT JOIN s.reputation r
+        JOIN a.category c
+        WHERE c.id = :categoryId
+        """
+    )
+    fun findSliceProjectionByCategoryId(
+        @Param("categoryId") categoryId: Int,
+        pageable: Pageable
+    ): Slice<AuctionListProjection>
+
+    @Query(
+        """
+        SELECT new com.back.domain.auction.auction.dto.response.AuctionListProjection(
+            a.id, a.name, a.startPrice, a.currentHighestBid, a.buyNowPrice, a.status, a.endAt, a.bidCount,
+            s.id, s.nickname, r.score, c.name, a.thumbnailUrl
+        )
+        FROM Auction a
+        JOIN a.seller s
+        LEFT JOIN s.reputation r
+        JOIN a.category c
+        WHERE a.status = :status
+        """
+    )
+    fun findSliceProjectionByStatus(
+        @Param("status") status: AuctionStatus,
+        pageable: Pageable
+    ): Slice<AuctionListProjection>
+
+    @Query(
+        """
+        SELECT new com.back.domain.auction.auction.dto.response.AuctionListProjection(
+            a.id, a.name, a.startPrice, a.currentHighestBid, a.buyNowPrice, a.status, a.endAt, a.bidCount,
+            s.id, s.nickname, r.score, c.name, a.thumbnailUrl
+        )
+        FROM Auction a
+        JOIN a.seller s
+        LEFT JOIN s.reputation r
+        JOIN a.category c
+        WHERE c.id = :categoryId AND a.status = :status
+        """
+    )
+    fun findSliceProjectionByCategoryIdAndStatus(
+        @Param("categoryId") categoryId: Int,
+        @Param("status") status: AuctionStatus,
+        pageable: Pageable
+    ): Slice<AuctionListProjection>
 
     @EntityGraph(attributePaths = ["seller", "seller.reputation", "category", "auctionImages", "auctionImages.image"])
     fun findWithDetailsById(id: Int): Optional<Auction>

--- a/src/main/java/com/back/domain/auction/auction/service/AuctionService.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/AuctionService.kt
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Caching
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.data.domain.Slice
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -114,26 +115,37 @@ class AuctionService(
     ): RsData<AuctionPageResponse> {
         val pageable = PageUtils.createPageable(page, size, createSort(sortBy))
         val auctionStatus = parseAuctionStatus(status)
-        val categoryId = categoryName?.takeIf { it.isNotBlank() }?.trim()
+        val category = categoryName?.takeIf { it.isNotBlank() }?.trim()
             ?.let { normalizedName ->
-                categoryPort.findByNameOrNull(normalizedName)?.id
+                categoryPort.findByNameOrNull(normalizedName)
                     ?: return RsData("200-1", "경매 목록 조회 성공", AuctionPageResponse.of(emptyList(), page, size, 0))
             }
+        val categoryId = category?.id
+        val resolvedCategoryName = category?.name
 
         val auctionSlice = when {
             categoryId != null && auctionStatus != null ->
-                auctionPersistencePort.findSliceProjectionByCategoryIdAndStatus(categoryId, auctionStatus, pageable)
+                auctionPersistencePort.findSliceProjectionByCategoryIdAndStatus(
+                    categoryId,
+                    auctionStatus,
+                    requireNotNull(resolvedCategoryName),
+                    pageable
+                )
             categoryId != null ->
-                auctionPersistencePort.findSliceProjectionByCategoryId(categoryId, pageable)
+                auctionPersistencePort.findSliceProjectionByCategoryId(
+                    categoryId,
+                    requireNotNull(resolvedCategoryName),
+                    pageable
+                )
             auctionStatus != null ->
                 auctionPersistencePort.findSliceProjectionByStatus(auctionStatus, pageable)
             else ->
                 auctionPersistencePort.findSliceProjectionAll(pageable)
         }
 
-        val content = auctionSlice.content.map { row -> row.toDto() }
         val countCacheKey = buildCountCacheKey(categoryId, auctionStatus)
-        val totalElements = auctionCountService.getTotalCount(countCacheKey, categoryId, auctionStatus)
+        val totalElements = resolveTotalElements(page, size, auctionSlice, countCacheKey, categoryId, auctionStatus)
+        val content = auctionSlice.content.map { row -> row.toDto() }
 
         return RsData("200-1", "경매 목록 조회 성공", AuctionPageResponse.of(content, page, size, totalElements))
     }
@@ -193,6 +205,25 @@ class AuctionService(
 
     private fun buildCountCacheKey(categoryId: Int?, status: AuctionStatus?): String =
         "category:${categoryId ?: "ALL"}:status:${status?.name ?: "ALL"}"
+
+    private fun resolveTotalElements(
+        page: Int,
+        size: Int,
+        auctionSlice: Slice<*>,
+        countCacheKey: String,
+        categoryId: Int?,
+        auctionStatus: AuctionStatus?
+    ): Long {
+        val currentElements = auctionSlice.numberOfElements.toLong()
+
+        // 첫 페이지에서 size 미만이면 남은 페이지가 없으므로 count 쿼리를 생략할 수 있다.
+        if (page == 0 && currentElements < size.toLong()) return currentElements
+
+        // 마지막 페이지면 현재 페이지 오프셋으로 전체 건수를 정확히 계산할 수 있다.
+        if (!auctionSlice.hasNext()) return page.toLong() * size + currentElements
+
+        return auctionCountService.getTotalCount(countCacheKey, categoryId, auctionStatus)
+    }
 
     fun buildAuctionListCacheKey(
         page: Int,

--- a/src/main/java/com/back/domain/auction/auction/service/AuctionService.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/AuctionService.kt
@@ -122,16 +122,16 @@ class AuctionService(
 
         val auctionSlice = when {
             categoryId != null && auctionStatus != null ->
-                auctionPersistencePort.findSliceByCategoryIdAndStatus(categoryId, auctionStatus, pageable)
+                auctionPersistencePort.findSliceProjectionByCategoryIdAndStatus(categoryId, auctionStatus, pageable)
             categoryId != null ->
-                auctionPersistencePort.findSliceByCategoryId(categoryId, pageable)
+                auctionPersistencePort.findSliceProjectionByCategoryId(categoryId, pageable)
             auctionStatus != null ->
-                auctionPersistencePort.findSliceByStatus(auctionStatus, pageable)
+                auctionPersistencePort.findSliceProjectionByStatus(auctionStatus, pageable)
             else ->
-                auctionPersistencePort.findSliceAll(pageable)
+                auctionPersistencePort.findSliceProjectionAll(pageable)
         }
 
-        val content = auctionSlice.content.map { auction -> AuctionListItemDto(auction) }
+        val content = auctionSlice.content.map { row -> row.toDto() }
         val countCacheKey = buildCountCacheKey(categoryId, auctionStatus)
         val totalElements = auctionCountService.getTotalCount(countCacheKey, categoryId, auctionStatus)
 

--- a/src/main/java/com/back/domain/auction/auction/service/adapter/AuctionPersistenceAdapter.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/adapter/AuctionPersistenceAdapter.kt
@@ -60,8 +60,12 @@ class AuctionPersistenceAdapter(
     override fun findSliceProjectionAll(pageable: Pageable): Slice<AuctionListProjection> =
         auctionRepository.findSliceProjectionBy(pageable)
 
-    override fun findSliceProjectionByCategoryId(categoryId: Int, pageable: Pageable): Slice<AuctionListProjection> =
-        auctionRepository.findSliceProjectionByCategoryId(categoryId, pageable)
+    override fun findSliceProjectionByCategoryId(
+        categoryId: Int,
+        categoryName: String,
+        pageable: Pageable
+    ): Slice<AuctionListProjection> =
+        auctionRepository.findSliceProjectionByCategoryId(categoryId, categoryName, pageable)
 
     override fun findSliceProjectionByStatus(status: AuctionStatus, pageable: Pageable): Slice<AuctionListProjection> =
         auctionRepository.findSliceProjectionByStatus(status, pageable)
@@ -69,9 +73,10 @@ class AuctionPersistenceAdapter(
     override fun findSliceProjectionByCategoryIdAndStatus(
         categoryId: Int,
         status: AuctionStatus,
+        categoryName: String,
         pageable: Pageable
     ): Slice<AuctionListProjection> =
-        auctionRepository.findSliceProjectionByCategoryIdAndStatus(categoryId, status, pageable)
+        auctionRepository.findSliceProjectionByCategoryIdAndStatus(categoryId, status, categoryName, pageable)
 
     override fun countAll(): Long = auctionRepository.count()
 

--- a/src/main/java/com/back/domain/auction/auction/service/adapter/AuctionPersistenceAdapter.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/adapter/AuctionPersistenceAdapter.kt
@@ -1,5 +1,6 @@
 package com.back.domain.auction.auction.service.adapter
 
+import com.back.domain.auction.auction.dto.response.AuctionListProjection
 import com.back.domain.auction.auction.entity.Auction
 import com.back.domain.auction.auction.entity.AuctionStatus
 import com.back.domain.auction.auction.repository.AuctionRepository
@@ -55,6 +56,22 @@ class AuctionPersistenceAdapter(
 
     override fun findSliceByCategoryIdAndStatus(categoryId: Int, status: AuctionStatus, pageable: Pageable): Slice<Auction> =
         auctionRepository.findSliceByCategoryIdAndStatus(categoryId, status, pageable)
+
+    override fun findSliceProjectionAll(pageable: Pageable): Slice<AuctionListProjection> =
+        auctionRepository.findSliceProjectionBy(pageable)
+
+    override fun findSliceProjectionByCategoryId(categoryId: Int, pageable: Pageable): Slice<AuctionListProjection> =
+        auctionRepository.findSliceProjectionByCategoryId(categoryId, pageable)
+
+    override fun findSliceProjectionByStatus(status: AuctionStatus, pageable: Pageable): Slice<AuctionListProjection> =
+        auctionRepository.findSliceProjectionByStatus(status, pageable)
+
+    override fun findSliceProjectionByCategoryIdAndStatus(
+        categoryId: Int,
+        status: AuctionStatus,
+        pageable: Pageable
+    ): Slice<AuctionListProjection> =
+        auctionRepository.findSliceProjectionByCategoryIdAndStatus(categoryId, status, pageable)
 
     override fun countAll(): Long = auctionRepository.count()
 

--- a/src/main/java/com/back/domain/auction/auction/service/port/AuctionPersistencePort.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/port/AuctionPersistencePort.kt
@@ -1,5 +1,6 @@
 package com.back.domain.auction.auction.service.port
 
+import com.back.domain.auction.auction.dto.response.AuctionListProjection
 import com.back.domain.auction.auction.entity.Auction
 import com.back.domain.auction.auction.entity.AuctionStatus
 import org.springframework.data.domain.Page
@@ -23,6 +24,14 @@ interface AuctionPersistencePort {
     fun findSliceByCategoryId(categoryId: Int, pageable: Pageable): Slice<Auction>
     fun findSliceByStatus(status: AuctionStatus, pageable: Pageable): Slice<Auction>
     fun findSliceByCategoryIdAndStatus(categoryId: Int, status: AuctionStatus, pageable: Pageable): Slice<Auction>
+    fun findSliceProjectionAll(pageable: Pageable): Slice<AuctionListProjection>
+    fun findSliceProjectionByCategoryId(categoryId: Int, pageable: Pageable): Slice<AuctionListProjection>
+    fun findSliceProjectionByStatus(status: AuctionStatus, pageable: Pageable): Slice<AuctionListProjection>
+    fun findSliceProjectionByCategoryIdAndStatus(
+        categoryId: Int,
+        status: AuctionStatus,
+        pageable: Pageable
+    ): Slice<AuctionListProjection>
     fun countAll(): Long
     fun countByStatus(status: AuctionStatus): Long
     fun countByCategoryId(categoryId: Int): Long

--- a/src/main/java/com/back/domain/auction/auction/service/port/AuctionPersistencePort.kt
+++ b/src/main/java/com/back/domain/auction/auction/service/port/AuctionPersistencePort.kt
@@ -25,11 +25,16 @@ interface AuctionPersistencePort {
     fun findSliceByStatus(status: AuctionStatus, pageable: Pageable): Slice<Auction>
     fun findSliceByCategoryIdAndStatus(categoryId: Int, status: AuctionStatus, pageable: Pageable): Slice<Auction>
     fun findSliceProjectionAll(pageable: Pageable): Slice<AuctionListProjection>
-    fun findSliceProjectionByCategoryId(categoryId: Int, pageable: Pageable): Slice<AuctionListProjection>
+    fun findSliceProjectionByCategoryId(
+        categoryId: Int,
+        categoryName: String,
+        pageable: Pageable
+    ): Slice<AuctionListProjection>
     fun findSliceProjectionByStatus(status: AuctionStatus, pageable: Pageable): Slice<AuctionListProjection>
     fun findSliceProjectionByCategoryIdAndStatus(
         categoryId: Int,
         status: AuctionStatus,
+        categoryName: String,
         pageable: Pageable
     ): Slice<AuctionListProjection>
     fun countAll(): Long

--- a/src/test/java/com/back/domain/auction/auction/service/AuctionServiceTest.kt
+++ b/src/test/java/com/back/domain/auction/auction/service/AuctionServiceTest.kt
@@ -120,21 +120,7 @@ class AuctionServiceTest {
     @DisplayName("경매 목록은 DTO 프로젝션 경로로 조회해도 응답 스펙을 유지한다.")
     fun t3_2() {
         val pageable = PageRequest.of(0, 20, Sort.by(Sort.Order.desc("createDate"), Sort.Order.desc("id")))
-        val row = AuctionListProjection(
-            auctionId = 1,
-            name = "테스트 경매",
-            startPrice = 10000,
-            currentHighestBid = 15000,
-            buyNowPrice = 30000,
-            status = AuctionStatus.OPEN,
-            endAt = LocalDateTime.now().plusHours(1),
-            bidCount = 3,
-            sellerId = 10,
-            sellerNickname = "seller",
-            sellerReputationScore = 4.7,
-            categoryName = "전자기기",
-            thumbnailUrl = "https://image.test/thumb.jpg"
-        )
+        val row = listProjection(auctionId = 1)
 
         `when`(auctionPersistencePort.findSliceProjectionAll(pageable))
             .thenReturn(SliceImpl(listOf(row), pageable, false))
@@ -147,6 +133,33 @@ class AuctionServiceTest {
         assertThat(result.data!!.content[0].auctionId).isEqualTo(1)
         assertThat(result.data!!.content[0].seller.nickname).isEqualTo("seller")
         assertThat(result.data!!.totalElements).isEqualTo(1L)
+    }
+
+    @Test
+    @DisplayName("첫 페이지에서 size보다 적게 조회되면 count 쿼리를 생략한다.")
+    fun t3_3() {
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Order.desc("createDate"), Sort.Order.desc("id")))
+        `when`(auctionPersistencePort.findSliceProjectionAll(pageable))
+            .thenReturn(SliceImpl(listOf(listProjection(auctionId = 1)), pageable, false))
+
+        val result = auctionService.getAuctions(0, 20, null, null, null)
+
+        assertThat(result.data!!.totalElements).isEqualTo(1L)
+        verify(auctionCountService, never()).getTotalCount("category:ALL:status:ALL", null, null)
+    }
+
+    @Test
+    @DisplayName("마지막 페이지에서는 count 쿼리 없이 전체 건수를 계산한다.")
+    fun t3_4() {
+        val pageable = PageRequest.of(2, 20, Sort.by(Sort.Order.desc("createDate"), Sort.Order.desc("id")))
+        val rows = listOf(listProjection(auctionId = 41), listProjection(auctionId = 42))
+        `when`(auctionPersistencePort.findSliceProjectionAll(pageable))
+            .thenReturn(SliceImpl(rows, pageable, false))
+
+        val result = auctionService.getAuctions(2, 20, null, null, null)
+
+        assertThat(result.data!!.totalElements).isEqualTo(42L)
+        verify(auctionCountService, never()).getTotalCount("category:ALL:status:ALL", null, null)
     }
 
     @Test
@@ -294,4 +307,20 @@ class AuctionServiceTest {
             .build()
             .also { ReflectionTestUtils.setField(it, "id", id) }
     }
+
+    private fun listProjection(auctionId: Int): AuctionListProjection = AuctionListProjection(
+        auctionId = auctionId,
+        name = "테스트 경매",
+        startPrice = 10000,
+        currentHighestBid = 15000,
+        buyNowPrice = 30000,
+        status = AuctionStatus.OPEN,
+        endAt = LocalDateTime.now().plusHours(1),
+        bidCount = 3,
+        sellerId = 10,
+        sellerNickname = "seller",
+        sellerReputationScore = 4.7,
+        categoryName = "전자기기",
+        thumbnailUrl = "https://image.test/thumb.jpg"
+    )
 }

--- a/src/test/java/com/back/domain/auction/auction/service/AuctionServiceTest.kt
+++ b/src/test/java/com/back/domain/auction/auction/service/AuctionServiceTest.kt
@@ -2,6 +2,7 @@ package com.back.domain.auction.auction.service
 
 import com.back.domain.auction.auction.dto.request.AuctionCreateRequest
 import com.back.domain.auction.auction.dto.request.AuctionUpdateRequest
+import com.back.domain.auction.auction.dto.response.AuctionListProjection
 import com.back.domain.auction.auction.entity.Auction
 import com.back.domain.auction.auction.entity.AuctionStatus
 import com.back.domain.auction.auction.service.port.AuctionImagePort
@@ -23,6 +24,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
 import org.springframework.data.domain.Sort
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.util.ReflectionTestUtils
@@ -112,6 +114,39 @@ class AuctionServiceTest {
         assertThat(result.data!!.content).isEmpty()
         assertThat(result.data!!.totalElements).isZero()
         assertThat(result.data!!.totalPages).isZero()
+    }
+
+    @Test
+    @DisplayName("경매 목록은 DTO 프로젝션 경로로 조회해도 응답 스펙을 유지한다.")
+    fun t3_2() {
+        val pageable = PageRequest.of(0, 20, Sort.by(Sort.Order.desc("createDate"), Sort.Order.desc("id")))
+        val row = AuctionListProjection(
+            auctionId = 1,
+            name = "테스트 경매",
+            startPrice = 10000,
+            currentHighestBid = 15000,
+            buyNowPrice = 30000,
+            status = AuctionStatus.OPEN,
+            endAt = LocalDateTime.now().plusHours(1),
+            bidCount = 3,
+            sellerId = 10,
+            sellerNickname = "seller",
+            sellerReputationScore = 4.7,
+            categoryName = "전자기기",
+            thumbnailUrl = "https://image.test/thumb.jpg"
+        )
+
+        `when`(auctionPersistencePort.findSliceProjectionAll(pageable))
+            .thenReturn(SliceImpl(listOf(row), pageable, false))
+        `when`(auctionCountService.getTotalCount("category:ALL:status:ALL", null, null)).thenReturn(1L)
+
+        val result = auctionService.getAuctions(0, 20, null, null, null)
+
+        assertThat(result.resultCode).isEqualTo("200-1")
+        assertThat(result.data!!.content).hasSize(1)
+        assertThat(result.data!!.content[0].auctionId).isEqualTo(1)
+        assertThat(result.data!!.content[0].seller.nickname).isEqualTo("seller")
+        assertThat(result.data!!.totalElements).isEqualTo(1L)
     }
 
     @Test


### PR DESCRIPTION
## 🔗 Issue 번호
- close #275

## 🛠 작업 내역
- 경매 목록 조회 전용 `AuctionListProjection` DTO 추가
- 목록 조회 리포지토리에 DTO 프로젝션 JPQL 조회(전체/카테고리/상태/카테고리+상태) 추가
- 서비스 포트/어댑터에 프로젝션 조회 메서드 추가
- `AuctionService.getAuctions`를 엔티티 Slice 경로에서 프로젝션 Slice 경로로 전환
- 프로젝션 경로에서도 응답 스펙이 유지되는 서비스 테스트 추가

## 🔄 변경 사항
- 목록 조회 시 엔티티 그래프 로딩 대신 필요한 컬럼만 조회하도록 변경
- 기존 응답 구조(`AuctionPageResponse`)는 유지
- count 캐시/목록 캐시 로직은 기존 정책을 유지한 채 조회 경로만 경량화

## ✨ 새로운 기능
- 없음 (기능 변경 없이 성능 최적화 리팩터링)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?