### PR TITLE
[Refactor/#278] Auction cancellerRole WINNER 스펙 호환 복원

### DIFF
--- a/src/main/java/com/back/domain/auction/auction/entity/Auction.kt
+++ b/src/main/java/com/back/domain/auction/auction/entity/Auction.kt
@@ -153,7 +153,7 @@ class Auction protected constructor() : BaseEntity() {
         }
 
         if (seller.id == memberId) return CancellerRole.SELLER
-        if (winnerId != null && winnerId == memberId) return CancellerRole.BUYER
+        if (winnerId != null && winnerId == memberId) return CancellerRole.WINNER
 
         throw IllegalArgumentException("거래를 취소할 권한이 없습니다.")
     }

--- a/src/main/java/com/back/domain/auction/auction/entity/CancellerRole.kt
+++ b/src/main/java/com/back/domain/auction/auction/entity/CancellerRole.kt
@@ -4,5 +4,5 @@ enum class CancellerRole(
     val description: String
 ) {
     SELLER("판매자"),
-    BUYER("구매자")
+    WINNER("낙찰자")
 }

--- a/src/main/resources/db/migration/V20260303_01__rename_auction_canceller_role_buyer_to_winner.sql
+++ b/src/main/resources/db/migration/V20260303_01__rename_auction_canceller_role_buyer_to_winner.sql
@@ -1,0 +1,3 @@
+UPDATE auction
+SET canceller_role = 'WINNER'
+WHERE canceller_role = 'BUYER';

--- a/src/test/java/com/back/domain/auction/auction/controller/AuctionControllerTest.kt
+++ b/src/test/java/com/back/domain/auction/auction/controller/AuctionControllerTest.kt
@@ -642,7 +642,7 @@ class AuctionControllerTest {
         val cancelledAuction = auctionRepository.findById(auctionId).orElseThrow()
         Assertions.assertThat(cancelledAuction.status).isEqualTo(AuctionStatus.CANCELLED)
         Assertions.assertThat(cancelledAuction.cancelledBy).isEqualTo(winner.id)
-        Assertions.assertThat(cancelledAuction.cancellerRole?.name).isEqualTo("BUYER")
+        Assertions.assertThat(cancelledAuction.cancellerRole?.name).isEqualTo("WINNER")
     }
 
     @Test


### PR DESCRIPTION
## 🔗 Issue 번호
- close #278

## 🛠 작업 내역
- `CancellerRole` enum의 `BUYER`를 `WINNER`로 변경
- 거래 취소 권한 판정 로직에서 낙찰자 역할 반환값을 `WINNER`로 변경
- 경매 컨트롤러 테스트 기대값(`BUYER` -> `WINNER`) 수정
- 기존 DB 데이터 호환을 위해 `auction.canceller_role` 값 `BUYER` -> `WINNER` 변환 Flyway 추가

## 🔄 변경 사항
- Java 기준 응답 스펙(`SELLER | WINNER | null`)과 Kotlin 응답값을 일치시킴
- 기존 데이터가 있어도 마이그레이션으로 안전하게 호환 유지

## ✨ 새로운 기능
- 없음 (스펙 호환 복원 리팩터링)

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?